### PR TITLE
Expand standard SQL support and add Oracle dialect

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,15 @@ Cyqwel is a dialect-neutral SQL toolkit for .NET. It parses SQL into an immutabl
 
 ## Features
 
-- Shared AST for Generic SQL, T-SQL, SQLite, PostgreSQL, and MySQL
+- Shared AST for Generic SQL, T-SQL, SQLite, PostgreSQL, MySQL, and Oracle
 - Reusable, compiled [Parlot](https://github.com/sebastienros/parlot) parser graphs cached by dialect configuration
 - Strict dialect parsing with distinct quote, parameter, operator, clause, and DML rules
 - Read-only visitor, non-mutating rewriter, depth-first and breadth-first traversal
 - Dialect-aware generation and transpilation
 - Window functions with `OVER`, `PARTITION BY`, and window ordering
+- Window frames, named window definitions, aggregate `FILTER`, and `WITHIN GROUP`
+- `VALUES` queries, `MERGE`, extended DML, and core relational DDL
+- Oracle bind variables, `MINUS`, sequences, hierarchical queries, and row limiting
 - Public dialect base class, registry, and fluent custom dialect builder
 - Custom literal and argument-aware function rendering hooks
 - Fluent SELECT, set-operation, INSERT, UPDATE, DELETE, CASE, and expression builders
@@ -102,4 +105,12 @@ Custom dialects inherit the base dialect's parser configuration and can modify o
 
 ## Supported SQL surface
 
-Cyqwel currently handles SELECT projections and aliases, joins, predicates, grouping, ordering, row limits, CTEs, set operations, INSERT VALUES/SELECT, UPDATE, DELETE, RETURNING, functions, CASE, CAST, subqueries, parameters, and common unary and binary operators. The AST and dialect hooks are designed to add syntax without coupling transformations to a specific parser or generator.
+Cyqwel handles:
+
+- Queries: `SELECT`, `VALUES`, joins with `ON` or `USING`, natural joins, predicates, grouping, ordering, row limits, recursive/materialized CTEs, named windows, window frames, and set operations.
+- Expressions: functions and aggregate modifiers, `CASE`, `CAST`/`TRY_CAST`, rows, intervals, extraction, collation, sequences, subqueries, parameters, boolean tests, and common unary and binary operators.
+- DML: `INSERT VALUES`/`SELECT`, `UPDATE ... FROM`, `DELETE ... USING`, `MERGE`, `RETURNING`, and Oracle `RETURNING ... INTO`.
+- DDL: create/alter/drop/truncate tables, columns and common constraints, views, indexes, and sequences.
+- Oracle: colon bind variables, `MINUS`, `FETCH FIRST`, `NEXTVAL`/`CURRVAL`, `START WITH`/`CONNECT BY`, `PRIOR`, `ORDER SIBLINGS BY`, and common function normalization.
+
+The built-in scope targets standard relational databases. Warehouse-only statements and engine-specific administration commands remain outside the shared AST unless they overlap common RDBMS SQL.

--- a/src/Cyqwel/Ast/Clauses.cs
+++ b/src/Cyqwel/Ast/Clauses.cs
@@ -46,7 +46,9 @@ public sealed record JoinTable(
     TableSource Right,
     JoinKind Kind,
     SqlExpression? Condition = null,
-    JoinSyntax Syntax = JoinSyntax.Explicit) : TableSource;
+    JoinSyntax Syntax = JoinSyntax.Explicit,
+    IReadOnlyList<SqlIdentifier>? Using = null,
+    bool IsNatural = false) : TableSource;
 
 public sealed record SelectItem(SqlExpression Expression, SqlIdentifier? Alias = null) : SqlNode
 {
@@ -78,6 +80,75 @@ public sealed record OrderByItem(
 public sealed record CommonTableExpression(
     SqlIdentifier Name,
     SqlQuery Query,
-    IReadOnlyList<SqlIdentifier>? Columns = null) : SqlNode;
+    IReadOnlyList<SqlIdentifier>? Columns = null,
+    CteMaterialization Materialization = CteMaterialization.Unspecified) : SqlNode;
 
 public sealed record Assignment(ColumnExpression Column, SqlExpression Value) : SqlNode;
+
+public enum CteMaterialization
+{
+    Unspecified,
+    Materialized,
+    NotMaterialized,
+}
+
+public sealed record WindowDefinition(
+    SqlIdentifier Name,
+    SqlIdentifier? BaseWindow = null,
+    IReadOnlyList<SqlExpression>? PartitionBy = null,
+    IReadOnlyList<OrderByItem>? OrderBy = null,
+    WindowFrame? Frame = null) : SqlNode;
+
+public enum WindowFrameUnit
+{
+    Rows,
+    Range,
+    Groups,
+}
+
+public enum WindowFrameBoundKind
+{
+    UnboundedPreceding,
+    Preceding,
+    CurrentRow,
+    Following,
+    UnboundedFollowing,
+}
+
+public sealed record WindowFrameBound(
+    WindowFrameBoundKind Kind,
+    SqlExpression? Offset = null) : SqlNode;
+
+public sealed record WindowFrame(
+    WindowFrameUnit Unit,
+    WindowFrameBound Start,
+    WindowFrameBound? End = null) : SqlNode;
+
+public sealed record ConnectByClause(
+    SqlExpression Condition,
+    SqlExpression? StartWith = null,
+    bool NoCycle = false) : SqlNode;
+
+public enum MergeMatchKind
+{
+    Matched,
+    NotMatched,
+    NotMatchedBySource,
+}
+
+public abstract record MergeAction : SqlNode;
+
+public sealed record MergeUpdateAction(
+    IReadOnlyList<Assignment> Assignments,
+    SqlExpression? DeleteWhere = null) : MergeAction;
+
+public sealed record MergeInsertAction(
+    IReadOnlyList<SqlIdentifier>? Columns,
+    IReadOnlyList<SqlExpression> Values) : MergeAction;
+
+public sealed record MergeDeleteAction : MergeAction;
+
+public sealed record MergeWhenClause(
+    MergeMatchKind MatchKind,
+    MergeAction Action,
+    SqlExpression? Condition = null) : SqlNode;

--- a/src/Cyqwel/Ast/Ddl.cs
+++ b/src/Cyqwel/Ast/Ddl.cs
@@ -1,0 +1,200 @@
+namespace Cyqwel.Ast;
+
+public abstract record TableElement : SqlNode;
+
+public enum Nullability
+{
+    Unspecified,
+    Null,
+    NotNull,
+}
+
+public enum GeneratedColumnKind
+{
+    Virtual,
+    Stored,
+}
+
+public enum IdentityGeneration
+{
+    None,
+    Always,
+    ByDefault,
+}
+
+public sealed record ColumnDefinition(
+    SqlIdentifier Name,
+    SqlDataType DataType,
+    Nullability Nullability = Nullability.Unspecified,
+    SqlExpression? Default = null,
+    SqlExpression? GeneratedExpression = null,
+    GeneratedColumnKind GeneratedKind = GeneratedColumnKind.Virtual,
+    IdentityGeneration Identity = IdentityGeneration.None,
+    bool IsPrimaryKey = false,
+    bool IsUnique = false) : TableElement;
+
+public abstract record TableConstraint : TableElement
+{
+    public SqlIdentifier? Name { get; init; }
+}
+
+public sealed record PrimaryKeyConstraint(
+    IReadOnlyList<SqlIdentifier> Columns) : TableConstraint
+{
+    public PrimaryKeyConstraint(
+        IReadOnlyList<SqlIdentifier> columns,
+        SqlIdentifier? name)
+        : this(columns)
+    {
+        Name = name;
+    }
+}
+
+public sealed record UniqueConstraint(
+    IReadOnlyList<SqlIdentifier> Columns) : TableConstraint
+{
+    public UniqueConstraint(
+        IReadOnlyList<SqlIdentifier> columns,
+        SqlIdentifier? name)
+        : this(columns)
+    {
+        Name = name;
+    }
+}
+
+public enum ReferentialAction
+{
+    Unspecified,
+    Cascade,
+    Restrict,
+    SetNull,
+    SetDefault,
+    NoAction,
+}
+
+public sealed record ForeignKeyConstraint(
+    IReadOnlyList<SqlIdentifier> Columns,
+    TableName ReferencedTable,
+    IReadOnlyList<SqlIdentifier> ReferencedColumns,
+    ReferentialAction OnDelete = ReferentialAction.Unspecified,
+    ReferentialAction OnUpdate = ReferentialAction.Unspecified) : TableConstraint
+{
+    public ForeignKeyConstraint(
+        IReadOnlyList<SqlIdentifier> columns,
+        TableName referencedTable,
+        IReadOnlyList<SqlIdentifier> referencedColumns,
+        ReferentialAction onDelete,
+        ReferentialAction onUpdate,
+        SqlIdentifier? name)
+        : this(columns, referencedTable, referencedColumns, onDelete, onUpdate)
+    {
+        Name = name;
+    }
+}
+
+public sealed record CheckConstraint(
+    SqlExpression Condition) : TableConstraint
+{
+    public CheckConstraint(SqlExpression condition, SqlIdentifier? name)
+        : this(condition)
+    {
+        Name = name;
+    }
+}
+
+public sealed record CreateTableStatement(
+    TableName Name,
+    IReadOnlyList<TableElement> Elements,
+    bool IfNotExists = false,
+    bool IsTemporary = false,
+    SqlQuery? AsQuery = null) : SqlStatement;
+
+public abstract record AlterTableAction : SqlNode;
+
+public sealed record AddColumnAction(ColumnDefinition Column) : AlterTableAction;
+
+public sealed record DropColumnAction(
+    SqlIdentifier Column,
+    bool IfExists = false,
+    bool Cascade = false) : AlterTableAction;
+
+public sealed record AlterColumnAction(
+    SqlIdentifier Column,
+    SqlDataType? DataType = null,
+    Nullability Nullability = Nullability.Unspecified,
+    SqlExpression? Default = null,
+    bool DropDefault = false) : AlterTableAction;
+
+public sealed record AddConstraintAction(TableConstraint Constraint) : AlterTableAction;
+
+public sealed record DropConstraintAction(
+    SqlIdentifier Constraint,
+    bool IfExists = false,
+    bool Cascade = false) : AlterTableAction;
+
+public sealed record RenameColumnAction(
+    SqlIdentifier Column,
+    SqlIdentifier NewName) : AlterTableAction;
+
+public sealed record RenameTableAction(SqlIdentifier NewName) : AlterTableAction;
+
+public sealed record AlterTableStatement(
+    TableName Name,
+    IReadOnlyList<AlterTableAction> Actions) : SqlStatement;
+
+public enum SchemaObjectKind
+{
+    Table,
+    View,
+    Index,
+    Schema,
+    Sequence,
+}
+
+public sealed record DropStatement(
+    SchemaObjectKind Kind,
+    IReadOnlyList<TableName> Names,
+    bool IfExists = false,
+    bool Cascade = false) : SqlStatement;
+
+public sealed record TruncateStatement(
+    IReadOnlyList<TableName> Tables,
+    bool RestartIdentity = false,
+    bool Cascade = false) : SqlStatement;
+
+public sealed record CreateViewStatement(
+    TableName Name,
+    SqlQuery Query,
+    IReadOnlyList<SqlIdentifier>? Columns = null,
+    bool OrReplace = false,
+    bool IsTemporary = false) : SqlStatement;
+
+public sealed record IndexColumn(
+    SqlExpression Expression,
+    OrderDirection Direction = OrderDirection.Unspecified,
+    NullOrder NullOrder = NullOrder.Unspecified) : SqlNode;
+
+public sealed record CreateIndexStatement(
+    TableName Name,
+    TableName Table,
+    IReadOnlyList<IndexColumn> Columns,
+    bool IsUnique = false,
+    bool IfNotExists = false,
+    SqlExpression? Where = null) : SqlStatement;
+
+public sealed record SequenceOptions(
+    SqlExpression? StartWith = null,
+    SqlExpression? IncrementBy = null,
+    SqlExpression? MinimumValue = null,
+    SqlExpression? MaximumValue = null,
+    SqlExpression? Cache = null,
+    bool? Cycle = null) : SqlNode;
+
+public sealed record CreateSequenceStatement(
+    TableName Name,
+    SequenceOptions Options,
+    bool IfNotExists = false) : SqlStatement;
+
+public sealed record AlterSequenceStatement(
+    TableName Name,
+    SequenceOptions Options) : SqlStatement;

--- a/src/Cyqwel/Ast/Expressions.cs
+++ b/src/Cyqwel/Ast/Expressions.cs
@@ -41,6 +41,8 @@ public enum UnaryOperator
     Minus,
     Not,
     BitwiseNot,
+    Prior,
+    ConnectByRoot,
 }
 
 public sealed record UnaryExpression(UnaryOperator Operator, SqlExpression Operand) : SqlExpression;
@@ -95,10 +97,55 @@ public sealed record InExpression(
 
 public sealed record IsNullExpression(SqlExpression Expression, bool IsNegated = false) : SqlExpression;
 
+public enum BooleanTestKind
+{
+    True,
+    False,
+    Unknown,
+}
+
+public sealed record BooleanTestExpression(
+    SqlExpression Expression,
+    BooleanTestKind Kind,
+    bool IsNegated = false) : SqlExpression;
+
+public sealed record DistinctFromExpression(
+    SqlExpression Left,
+    SqlExpression Right,
+    bool IsNegated = false) : SqlExpression;
+
+public sealed record RowExpression(IReadOnlyList<SqlExpression> Values) : SqlExpression;
+
+public sealed record DefaultExpression : SqlExpression;
+
+public sealed record CollateExpression(
+    SqlExpression Expression,
+    SqlIdentifier Collation) : SqlExpression;
+
+public sealed record ExtractExpression(
+    SqlIdentifier Field,
+    SqlExpression Expression) : SqlExpression;
+
+public sealed record IntervalExpression(
+    SqlExpression Value,
+    SqlIdentifier Unit) : SqlExpression;
+
+public enum SequenceValueKind
+{
+    Next,
+    Current,
+}
+
+public sealed record SequenceValueExpression(
+    TableName Sequence,
+    SequenceValueKind Kind) : SqlExpression;
+
 public sealed record FunctionCallExpression(
     SqlIdentifier Name,
     IReadOnlyList<SqlExpression> Arguments,
-    bool IsDistinct = false) : SqlExpression
+    bool IsDistinct = false,
+    SqlExpression? Filter = null,
+    IReadOnlyList<OrderByItem>? WithinGroup = null) : SqlExpression
 {
     public FunctionCallExpression(string name, params SqlExpression[] arguments)
         : this(new SqlIdentifier(name), arguments)
@@ -109,7 +156,9 @@ public sealed record FunctionCallExpression(
 public sealed record WindowExpression(
     SqlExpression Expression,
     IReadOnlyList<SqlExpression>? PartitionBy = null,
-    IReadOnlyList<OrderByItem>? OrderBy = null) : SqlExpression;
+    IReadOnlyList<OrderByItem>? OrderBy = null,
+    WindowFrame? Frame = null,
+    SqlIdentifier? WindowName = null) : SqlExpression;
 
 public sealed record ExistsExpression(SqlQuery Query, bool IsNegated = false) : SqlExpression;
 
@@ -123,6 +172,8 @@ public sealed record CaseExpression(
     SqlExpression? Else = null) : SqlExpression;
 
 public sealed record CastExpression(SqlExpression Expression, SqlDataType DataType) : SqlExpression;
+
+public sealed record TryCastExpression(SqlExpression Expression, SqlDataType DataType) : SqlExpression;
 
 public sealed record SqlDataType(
     SqlIdentifier Name,

--- a/src/Cyqwel/Ast/Statements.cs
+++ b/src/Cyqwel/Ast/Statements.cs
@@ -13,7 +13,20 @@ public sealed record SelectStatement(
     IReadOnlyList<CommonTableExpression>? CommonTableExpressions = null,
     SqlExpression? Top = null,
     bool IsTopPercent = false,
-    bool WithTies = false) : SqlQuery;
+    bool WithTies = false,
+    bool IsRecursive = false,
+    IReadOnlyList<WindowDefinition>? Windows = null,
+    SqlExpression? Qualify = null,
+    ConnectByClause? ConnectBy = null,
+    bool OrderSiblings = false) : SqlQuery;
+
+public sealed record ValuesStatement(
+    IReadOnlyList<IReadOnlyList<SqlExpression>> Rows,
+    IReadOnlyList<OrderByItem>? OrderBy = null,
+    SqlExpression? Limit = null,
+    SqlExpression? Offset = null,
+    bool IsRecursive = false,
+    IReadOnlyList<CommonTableExpression>? CommonTableExpressions = null) : SqlQuery;
 
 public enum SetOperator
 {
@@ -29,22 +42,37 @@ public sealed record SetOperationStatement(
     bool IsAll = false,
     IReadOnlyList<OrderByItem>? OrderBy = null,
     SqlExpression? Limit = null,
-    SqlExpression? Offset = null) : SqlQuery;
+    SqlExpression? Offset = null,
+    bool IsRecursive = false,
+    IReadOnlyList<CommonTableExpression>? CommonTableExpressions = null) : SqlQuery;
 
 public sealed record InsertStatement(
     TableName Target,
     IReadOnlyList<SqlIdentifier>? Columns,
     IReadOnlyList<IReadOnlyList<SqlExpression>>? Values = null,
     SqlQuery? Source = null,
-    IReadOnlyList<SqlExpression>? Returning = null) : SqlStatement;
+    IReadOnlyList<SqlExpression>? Returning = null,
+    IReadOnlyList<SqlExpression>? ReturningInto = null) : SqlStatement;
 
 public sealed record UpdateStatement(
     NamedTable Target,
     IReadOnlyList<Assignment> Assignments,
     SqlExpression? Where = null,
-    IReadOnlyList<SqlExpression>? Returning = null) : SqlStatement;
+    IReadOnlyList<SqlExpression>? Returning = null,
+    IReadOnlyList<SqlExpression>? ReturningInto = null,
+    TableSource? From = null) : SqlStatement;
 
 public sealed record DeleteStatement(
     NamedTable Target,
     SqlExpression? Where = null,
-    IReadOnlyList<SqlExpression>? Returning = null) : SqlStatement;
+    IReadOnlyList<SqlExpression>? Returning = null,
+    IReadOnlyList<SqlExpression>? ReturningInto = null,
+    TableSource? Using = null) : SqlStatement;
+
+public sealed record MergeStatement(
+    NamedTable Target,
+    TableSource Source,
+    SqlExpression Condition,
+    IReadOnlyList<MergeWhenClause> WhenClauses,
+    IReadOnlyList<SqlExpression>? Returning = null,
+    IReadOnlyList<SqlExpression>? ReturningInto = null) : SqlStatement;

--- a/src/Cyqwel/Dialects/SqlDialect.cs
+++ b/src/Cyqwel/Dialects/SqlDialect.cs
@@ -12,6 +12,7 @@ public enum SqlLimitStyle
     Top,
     OffsetFetch,
     LimitOffsetComma,
+    FetchFirst,
 }
 
 public enum SqlConcatenationStyle
@@ -34,7 +35,8 @@ public class SqlDialect
         "INTO", "IS", "JOIN", "LAST", "LEFT", "LIKE", "LIMIT", "NEXT", "NOT", "NULL",
         "NULLS", "OFFSET", "ON", "ONLY", "OR", "ORDER", "OUTER", "RETURNING", "RIGHT",
         "ROW", "ROWS", "SELECT", "SET", "THEN", "TOP", "TRUE", "UNION", "UPDATE", "VALUES",
-        "WHEN", "WHERE", "WITH",
+        "WHEN", "WHERE", "WITH", "MERGE", "CREATE", "ALTER", "DROP", "TRUNCATE", "TABLE",
+        "VIEW", "INDEX", "SEQUENCE", "CONNECT", "PRIOR", "START", "SIBLINGS",
     };
 
     public SqlDialect(
@@ -62,7 +64,11 @@ public class SqlDialect
 
     public virtual bool SupportsReturning => true;
 
+    public virtual bool SupportsReturningInto => ParserOptions.SupportsReturningInto;
+
     public virtual bool RequiresOrderByForOffset => false;
+
+    public virtual bool SupportsTableAliasAs => true;
 
     public virtual SqlConcatenationStyle ConcatenationStyle => SqlConcatenationStyle.DoublePipe;
 
@@ -78,6 +84,14 @@ public class SqlDialect
 
     public virtual string GetFunctionName(string name) => name;
 
+    public virtual string GetSetOperator(SetOperator value) => value switch
+    {
+        SetOperator.Union => "UNION",
+        SetOperator.Intersect => "INTERSECT",
+        SetOperator.Except => "EXCEPT",
+        _ => throw new ArgumentOutOfRangeException(nameof(value)),
+    };
+
     public virtual string? RenderLiteral(
         LiteralExpression literal,
         SqlGenerationOptions options) => null;
@@ -86,6 +100,8 @@ public class SqlDialect
         FunctionCallExpression function,
         Func<SqlExpression, string> renderExpression,
         SqlGenerationOptions options) => null;
+
+    public virtual string? RenderParameter(ParameterExpression parameter) => null;
 
     public virtual bool ShouldQuoteIdentifier(SqlIdentifier identifier) =>
         identifier.IsQuoted
@@ -149,8 +165,10 @@ public static class SqlDialects
 
     public static SqlDialect MySql { get; } = new MySqlDialect();
 
+    public static SqlDialect Oracle { get; } = new OracleDialect();
+
     public static IReadOnlyList<SqlDialect> BuiltIn { get; } =
-        [Generic, TSql, Sqlite, PostgreSql, MySql];
+        [Generic, TSql, Sqlite, PostgreSql, MySql, Oracle];
 
     private sealed class GenericDialect() : SqlDialect("generic");
 
@@ -243,6 +261,83 @@ public static class SqlDialects
 
         public override string GetFunctionName(string name) =>
             name.Equals("COALESCE", StringComparison.OrdinalIgnoreCase) ? "COALESCE" : name;
+    }
+
+    private sealed class OracleDialect() : SqlDialect("oracle", limitStyle: SqlLimitStyle.FetchFirst)
+    {
+        public override bool SupportsTableAliasAs => false;
+        public override SqlDialectParserOptions ParserOptions { get; } = new()
+        {
+            IdentifierQuotes = SqlIdentifierQuoteStyle.DoubleQuote,
+            ParameterStyles = SqlParameterStyle.ColonNamed,
+            SupportsLimit = false,
+            SupportsOffsetOnly = false,
+            SupportsOffsetFetch = true,
+            SupportsReturning = true,
+            SupportsReturningInto = true,
+            SupportsILike = false,
+            SupportsNullOrdering = true,
+            SupportsMinus = true,
+            SupportsRecursiveCte = false,
+            SupportsHierarchicalQueries = true,
+            SupportsTableAliasAs = false,
+            DoublePipeBehavior = SqlDoublePipeBehavior.Concatenate,
+        };
+
+        public override string TrueLiteral => "1";
+        public override string FalseLiteral => "0";
+
+        public override string GetFunctionName(string name) => name.ToUpperInvariant() switch
+        {
+            "IFNULL" => "NVL",
+            "SUBSTRING" => "SUBSTR",
+            "RANDOM" or "RAND" => "DBMS_RANDOM.VALUE",
+            _ => name,
+        };
+
+        public override string GetSetOperator(SetOperator value) =>
+            value == SetOperator.Except ? "MINUS" : base.GetSetOperator(value);
+
+        public override string? RenderFunction(
+            FunctionCallExpression function,
+            Func<SqlExpression, string> renderExpression,
+            SqlGenerationOptions options)
+        {
+            if (function.Name.Value.Equals("NOW", StringComparison.OrdinalIgnoreCase)
+                || function.Name.Value.Equals("CURRENT_TIMESTAMP", StringComparison.OrdinalIgnoreCase)
+                    && function.Arguments.Count == 0)
+            {
+                return "SYSTIMESTAMP";
+            }
+
+            if (function.Name.Value.Equals("COALESCE", StringComparison.OrdinalIgnoreCase)
+                && function.Arguments.Count == 2)
+            {
+                return $"NVL({renderExpression(function.Arguments[0])}, {renderExpression(function.Arguments[1])})";
+            }
+
+            return null;
+        }
+
+        public override string? RenderParameter(ParameterExpression parameter) =>
+            parameter.Name.Length == 0 ? null : $":{parameter.Name}";
+
+        public override SqlNode TransformNode(SqlNode node) => node switch
+        {
+            TryCastExpression value => new CastExpression(value.Expression, value.DataType)
+            {
+                Span = value.Span,
+            },
+            BinaryExpression { Operator: BinaryOperator.ILike or BinaryOperator.NotILike } value =>
+                new BinaryExpression(
+                    new FunctionCallExpression("LOWER", value.Left),
+                    value.Operator == BinaryOperator.ILike ? BinaryOperator.Like : BinaryOperator.NotLike,
+                    new FunctionCallExpression("LOWER", value.Right))
+                {
+                    Span = value.Span,
+                },
+            _ => node,
+        };
     }
 }
 
@@ -395,7 +490,9 @@ public sealed class SqlDialectBuilder
     {
         public override bool SupportsILike => baseDialect.SupportsILike;
         public override bool SupportsReturning => baseDialect.SupportsReturning;
+        public override bool SupportsReturningInto => baseDialect.SupportsReturningInto;
         public override bool RequiresOrderByForOffset => baseDialect.RequiresOrderByForOffset;
+        public override bool SupportsTableAliasAs => baseDialect.SupportsTableAliasAs;
         public override SqlConcatenationStyle ConcatenationStyle => baseDialect.ConcatenationStyle;
         public override SqlDialectParserOptions ParserOptions { get; } =
             parserOptions is null
@@ -415,6 +512,9 @@ public sealed class SqlDialectBuilder
                 ? baseDialect.GetFunctionName(value)
                 : functionName(baseDialect.GetFunctionName(value));
 
+        public override string GetSetOperator(SetOperator value) =>
+            baseDialect.GetSetOperator(value);
+
         public override string? RenderLiteral(
             LiteralExpression literal,
             SqlGenerationOptions options) =>
@@ -427,6 +527,9 @@ public sealed class SqlDialectBuilder
             SqlGenerationOptions options) =>
             functionRenderer?.Invoke(function, renderExpression, options)
             ?? baseDialect.RenderFunction(function, renderExpression, options);
+
+        public override string? RenderParameter(ParameterExpression parameter) =>
+            baseDialect.RenderParameter(parameter);
 
         public override bool ShouldQuoteIdentifier(SqlIdentifier identifier) =>
             baseDialect.ShouldQuoteIdentifier(identifier);

--- a/src/Cyqwel/Generation/SqlGenerator.Standard.cs
+++ b/src/Cyqwel/Generation/SqlGenerator.Standard.cs
@@ -1,0 +1,647 @@
+using Cyqwel.Ast;
+
+namespace Cyqwel.Generation;
+
+public sealed partial class SqlGenerator
+{
+    private void WriteValues(ValuesStatement values)
+    {
+        WriteCommonTableExpressions(values.CommonTableExpressions, values.IsRecursive);
+        Keyword("VALUES");
+        Space();
+        WriteSeparated(values.Rows, row =>
+        {
+            _builder.Append('(');
+            WriteSeparated(row, value => WriteExpression(value));
+            _builder.Append(')');
+        });
+        WriteOrderBy(values.OrderBy);
+        WriteLimitOffset(values.Limit, values.Offset, values.OrderBy);
+    }
+
+    private void WriteMerge(MergeStatement merge)
+    {
+        Keyword("MERGE INTO");
+        Space();
+        WriteNamedTable(merge.Target);
+        ClauseBreak();
+        Keyword("USING");
+        Space();
+        WriteTableSource(merge.Source);
+        ClauseBreak();
+        Keyword("ON");
+        _builder.Append(" (");
+        WriteExpression(merge.Condition);
+        _builder.Append(')');
+
+        foreach (var when in merge.WhenClauses)
+        {
+            ClauseBreak();
+            Keyword("WHEN");
+            Space();
+            Keyword(when.MatchKind switch
+            {
+                MergeMatchKind.Matched => "MATCHED",
+                MergeMatchKind.NotMatched => "NOT MATCHED",
+                MergeMatchKind.NotMatchedBySource => "NOT MATCHED BY SOURCE",
+                _ => throw new ArgumentOutOfRangeException(),
+            });
+            if (when.Condition is not null)
+            {
+                Space();
+                Keyword("AND");
+                Space();
+                WriteExpression(when.Condition);
+            }
+
+            Space();
+            Keyword("THEN");
+            Space();
+            WriteMergeAction(when.Action);
+        }
+
+        WriteReturning(merge.Returning, merge.ReturningInto);
+    }
+
+    private void WriteMergeAction(MergeAction action)
+    {
+        switch (action)
+        {
+            case MergeUpdateAction update:
+                Keyword("UPDATE SET");
+                Space();
+                WriteSeparated(update.Assignments, assignment =>
+                {
+                    WriteExpression(assignment.Column);
+                    _builder.Append(" = ");
+                    WriteExpression(assignment.Value);
+                });
+                if (update.DeleteWhere is not null)
+                {
+                    Space();
+                    Keyword("DELETE WHERE");
+                    Space();
+                    WriteExpression(update.DeleteWhere);
+                }
+
+                break;
+            case MergeInsertAction insert:
+                Keyword("INSERT");
+                if (insert.Columns is { Count: > 0 })
+                {
+                    _builder.Append(" (");
+                    WriteSeparated(insert.Columns, WriteIdentifier);
+                    _builder.Append(')');
+                }
+
+                Space();
+                Keyword("VALUES");
+                _builder.Append(" (");
+                WriteSeparated(insert.Values, value => WriteExpression(value));
+                _builder.Append(')');
+                break;
+            case MergeDeleteAction:
+                Keyword("DELETE");
+                break;
+            default:
+                throw new NotSupportedException($"Unsupported MERGE action '{action.GetType().Name}'.");
+        }
+    }
+
+    private void WriteCreateTable(CreateTableStatement create)
+    {
+        Keyword("CREATE");
+        if (create.IsTemporary)
+        {
+            Space();
+            Keyword("TEMPORARY");
+        }
+
+        Space();
+        Keyword("TABLE");
+        if (create.IfNotExists)
+        {
+            Space();
+            Keyword("IF NOT EXISTS");
+        }
+
+        Space();
+        WriteTableName(create.Name);
+        if (create.Elements.Count > 0)
+        {
+            _builder.Append(" (");
+            WriteSeparated(create.Elements, WriteTableElement);
+            _builder.Append(')');
+        }
+
+        if (create.AsQuery is not null)
+        {
+            ClauseBreak();
+            Keyword("AS");
+            Space();
+            WriteNode(create.AsQuery);
+        }
+    }
+
+    private void WriteTableElement(TableElement element)
+    {
+        switch (element)
+        {
+            case ColumnDefinition column:
+                WriteColumnDefinition(column);
+                break;
+            case TableConstraint constraint:
+                WriteTableConstraint(constraint);
+                break;
+            default:
+                throw new NotSupportedException($"Unsupported table element '{element.GetType().Name}'.");
+        }
+    }
+
+    private void WriteColumnDefinition(ColumnDefinition column)
+    {
+        WriteIdentifier(column.Name);
+        Space();
+        WriteDataType(column.DataType);
+        if (column.Identity != IdentityGeneration.None)
+        {
+            Space();
+            Keyword(column.Identity == IdentityGeneration.Always
+                ? "GENERATED ALWAYS AS IDENTITY"
+                : "GENERATED BY DEFAULT AS IDENTITY");
+        }
+
+        if (column.Default is not null)
+        {
+            Space();
+            Keyword("DEFAULT");
+            Space();
+            WriteExpression(column.Default);
+        }
+
+        if (column.GeneratedExpression is not null)
+        {
+            Space();
+            Keyword("GENERATED ALWAYS AS");
+            _builder.Append(" (");
+            WriteExpression(column.GeneratedExpression);
+            _builder.Append(')');
+            Space();
+            Keyword(column.GeneratedKind == GeneratedColumnKind.Stored ? "STORED" : "VIRTUAL");
+        }
+
+        if (column.Nullability != Nullability.Unspecified)
+        {
+            Space();
+            Keyword(column.Nullability == Nullability.NotNull ? "NOT NULL" : "NULL");
+        }
+
+        if (column.IsPrimaryKey)
+        {
+            Space();
+            Keyword("PRIMARY KEY");
+        }
+
+        if (column.IsUnique)
+        {
+            Space();
+            Keyword("UNIQUE");
+        }
+    }
+
+    private void WriteTableConstraint(TableConstraint constraint)
+    {
+        if (constraint.Name is not null)
+        {
+            Keyword("CONSTRAINT");
+            Space();
+            WriteIdentifier(constraint.Name);
+            Space();
+        }
+
+        switch (constraint)
+        {
+            case PrimaryKeyConstraint primaryKey:
+                Keyword("PRIMARY KEY");
+                WriteIdentifierList(primaryKey.Columns);
+                break;
+            case UniqueConstraint unique:
+                Keyword("UNIQUE");
+                WriteIdentifierList(unique.Columns);
+                break;
+            case ForeignKeyConstraint foreignKey:
+                Keyword("FOREIGN KEY");
+                WriteIdentifierList(foreignKey.Columns);
+                Space();
+                Keyword("REFERENCES");
+                Space();
+                WriteTableName(foreignKey.ReferencedTable);
+                WriteIdentifierList(foreignKey.ReferencedColumns);
+                WriteReferentialAction("ON DELETE", foreignKey.OnDelete);
+                WriteReferentialAction("ON UPDATE", foreignKey.OnUpdate);
+                break;
+            case CheckConstraint check:
+                Keyword("CHECK");
+                _builder.Append(" (");
+                WriteExpression(check.Condition);
+                _builder.Append(')');
+                break;
+            default:
+                throw new NotSupportedException($"Unsupported table constraint '{constraint.GetType().Name}'.");
+        }
+    }
+
+    private void WriteIdentifierList(IReadOnlyList<SqlIdentifier> identifiers)
+    {
+        _builder.Append(" (");
+        WriteSeparated(identifiers, WriteIdentifier);
+        _builder.Append(')');
+    }
+
+    private void WriteReferentialAction(string clause, ReferentialAction action)
+    {
+        if (action == ReferentialAction.Unspecified) return;
+        Space();
+        Keyword(clause);
+        Space();
+        Keyword(action switch
+        {
+            ReferentialAction.Cascade => "CASCADE",
+            ReferentialAction.Restrict => "RESTRICT",
+            ReferentialAction.SetNull => "SET NULL",
+            ReferentialAction.SetDefault => "SET DEFAULT",
+            ReferentialAction.NoAction => "NO ACTION",
+            _ => throw new ArgumentOutOfRangeException(nameof(action)),
+        });
+    }
+
+    private void WriteAlterTable(AlterTableStatement alter)
+    {
+        Keyword("ALTER TABLE");
+        Space();
+        WriteTableName(alter.Name);
+        Space();
+        WriteSeparated(alter.Actions, WriteAlterTableAction);
+    }
+
+    private void WriteAlterTableAction(AlterTableAction action)
+    {
+        switch (action)
+        {
+            case AddColumnAction add:
+                Keyword("ADD COLUMN");
+                Space();
+                WriteColumnDefinition(add.Column);
+                break;
+            case DropColumnAction drop:
+                Keyword("DROP COLUMN");
+                if (drop.IfExists)
+                {
+                    Space();
+                    Keyword("IF EXISTS");
+                }
+
+                Space();
+                WriteIdentifier(drop.Column);
+                if (drop.Cascade)
+                {
+                    Space();
+                    Keyword("CASCADE");
+                }
+
+                break;
+            case AlterColumnAction alter:
+                Keyword("ALTER COLUMN");
+                Space();
+                WriteIdentifier(alter.Column);
+                if (alter.DataType is not null)
+                {
+                    Space();
+                    Keyword("TYPE");
+                    Space();
+                    WriteDataType(alter.DataType);
+                }
+                else if (alter.DropDefault)
+                {
+                    Space();
+                    Keyword("DROP DEFAULT");
+                }
+                else if (alter.Default is not null)
+                {
+                    Space();
+                    Keyword("SET DEFAULT");
+                    Space();
+                    WriteExpression(alter.Default);
+                }
+                else if (alter.Nullability != Nullability.Unspecified)
+                {
+                    Space();
+                    Keyword(alter.Nullability == Nullability.NotNull ? "SET NOT NULL" : "DROP NOT NULL");
+                }
+
+                break;
+            case AddConstraintAction add:
+                Keyword("ADD");
+                Space();
+                WriteTableConstraint(add.Constraint);
+                break;
+            case DropConstraintAction drop:
+                Keyword("DROP CONSTRAINT");
+                if (drop.IfExists)
+                {
+                    Space();
+                    Keyword("IF EXISTS");
+                }
+
+                Space();
+                WriteIdentifier(drop.Constraint);
+                if (drop.Cascade)
+                {
+                    Space();
+                    Keyword("CASCADE");
+                }
+
+                break;
+            case RenameColumnAction rename:
+                Keyword("RENAME COLUMN");
+                Space();
+                WriteIdentifier(rename.Column);
+                Space();
+                Keyword("TO");
+                Space();
+                WriteIdentifier(rename.NewName);
+                break;
+            case RenameTableAction rename:
+                Keyword("RENAME TO");
+                Space();
+                WriteIdentifier(rename.NewName);
+                break;
+            default:
+                throw new NotSupportedException($"Unsupported ALTER TABLE action '{action.GetType().Name}'.");
+        }
+    }
+
+    private void WriteDrop(DropStatement drop)
+    {
+        Keyword("DROP");
+        Space();
+        Keyword(drop.Kind.ToString().ToUpperInvariant());
+        if (drop.IfExists)
+        {
+            Space();
+            Keyword("IF EXISTS");
+        }
+
+        Space();
+        WriteSeparated(drop.Names, WriteTableName);
+        if (drop.Cascade)
+        {
+            Space();
+            Keyword("CASCADE");
+        }
+    }
+
+    private void WriteTruncate(TruncateStatement truncate)
+    {
+        Keyword("TRUNCATE TABLE");
+        Space();
+        WriteSeparated(truncate.Tables, WriteTableName);
+        if (truncate.RestartIdentity)
+        {
+            Space();
+            Keyword("RESTART IDENTITY");
+        }
+
+        if (truncate.Cascade)
+        {
+            Space();
+            Keyword("CASCADE");
+        }
+    }
+
+    private void WriteCreateView(CreateViewStatement create)
+    {
+        Keyword("CREATE");
+        if (create.OrReplace)
+        {
+            Space();
+            Keyword("OR REPLACE");
+        }
+
+        if (create.IsTemporary)
+        {
+            Space();
+            Keyword("TEMPORARY");
+        }
+
+        Space();
+        Keyword("VIEW");
+        Space();
+        WriteTableName(create.Name);
+        if (create.Columns is { Count: > 0 }) WriteIdentifierList(create.Columns);
+        Space();
+        Keyword("AS");
+        Space();
+        WriteNode(create.Query);
+    }
+
+    private void WriteCreateIndex(CreateIndexStatement create)
+    {
+        Keyword("CREATE");
+        if (create.IsUnique)
+        {
+            Space();
+            Keyword("UNIQUE");
+        }
+
+        Space();
+        Keyword("INDEX");
+        if (create.IfNotExists)
+        {
+            Space();
+            Keyword("IF NOT EXISTS");
+        }
+
+        Space();
+        WriteTableName(create.Name);
+        Space();
+        Keyword("ON");
+        Space();
+        WriteTableName(create.Table);
+        _builder.Append(" (");
+        WriteSeparated(create.Columns, column =>
+        {
+            WriteExpression(column.Expression);
+            if (column.Direction != OrderDirection.Unspecified)
+            {
+                Space();
+                Keyword(column.Direction == OrderDirection.Descending ? "DESC" : "ASC");
+            }
+
+            if (column.NullOrder != NullOrder.Unspecified)
+            {
+                Space();
+                Keyword(column.NullOrder == NullOrder.First ? "NULLS FIRST" : "NULLS LAST");
+            }
+        });
+        _builder.Append(')');
+        if (create.Where is not null)
+        {
+            Space();
+            Keyword("WHERE");
+            Space();
+            WriteExpression(create.Where);
+        }
+    }
+
+    private void WriteCreateSequence(CreateSequenceStatement create)
+    {
+        Keyword("CREATE SEQUENCE");
+        if (create.IfNotExists)
+        {
+            Space();
+            Keyword("IF NOT EXISTS");
+        }
+
+        Space();
+        WriteTableName(create.Name);
+        WriteSequenceOptions(create.Options);
+    }
+
+    private void WriteAlterSequence(AlterSequenceStatement alter)
+    {
+        Keyword("ALTER SEQUENCE");
+        Space();
+        WriteTableName(alter.Name);
+        WriteSequenceOptions(alter.Options);
+    }
+
+    private void WriteSequenceOptions(SequenceOptions options)
+    {
+        WriteSequenceOption("START WITH", options.StartWith);
+        WriteSequenceOption("INCREMENT BY", options.IncrementBy);
+        WriteSequenceOption("MINVALUE", options.MinimumValue);
+        WriteSequenceOption("MAXVALUE", options.MaximumValue);
+        WriteSequenceOption("CACHE", options.Cache);
+        if (options.Cycle.HasValue)
+        {
+            Space();
+            Keyword(options.Cycle.Value ? "CYCLE" : "NO CYCLE");
+        }
+    }
+
+    private void WriteSequenceOption(string name, SqlExpression? value)
+    {
+        if (value is null) return;
+        Space();
+        Keyword(name);
+        Space();
+        WriteExpression(value);
+    }
+
+    private void WriteWindowDefinition(WindowDefinition window)
+    {
+        WriteIdentifier(window.Name);
+        Space();
+        Keyword("AS");
+        _builder.Append(" (");
+        var hasClause = false;
+        if (window.BaseWindow is not null)
+        {
+            WriteIdentifier(window.BaseWindow);
+            hasClause = true;
+        }
+
+        if (window.PartitionBy is { Count: > 0 })
+        {
+            if (hasClause) Space();
+            Keyword("PARTITION BY");
+            Space();
+            WriteSeparated(window.PartitionBy, value => WriteExpression(value));
+            hasClause = true;
+        }
+
+        if (window.OrderBy is { Count: > 0 })
+        {
+            if (hasClause) Space();
+            Keyword("ORDER BY");
+            Space();
+            WriteOrderByItems(window.OrderBy);
+            hasClause = true;
+        }
+
+        if (window.Frame is not null)
+        {
+            if (hasClause) Space();
+            WriteWindowFrame(window.Frame);
+        }
+
+        _builder.Append(')');
+    }
+
+    private void WriteWindowFrame(WindowFrame frame)
+    {
+        Keyword(frame.Unit switch
+        {
+            WindowFrameUnit.Rows => "ROWS",
+            WindowFrameUnit.Range => "RANGE",
+            WindowFrameUnit.Groups => "GROUPS",
+            _ => throw new ArgumentOutOfRangeException(),
+        });
+        Space();
+        if (frame.End is null)
+        {
+            WriteWindowFrameBound(frame.Start);
+            return;
+        }
+
+        Keyword("BETWEEN");
+        Space();
+        WriteWindowFrameBound(frame.Start);
+        Space();
+        Keyword("AND");
+        Space();
+        WriteWindowFrameBound(frame.End);
+    }
+
+    private void WriteWindowFrameBound(WindowFrameBound bound)
+    {
+        if (bound.Offset is not null)
+        {
+            WriteExpression(bound.Offset);
+            Space();
+        }
+
+        Keyword(bound.Kind switch
+        {
+            WindowFrameBoundKind.UnboundedPreceding => "UNBOUNDED PRECEDING",
+            WindowFrameBoundKind.Preceding => "PRECEDING",
+            WindowFrameBoundKind.CurrentRow => "CURRENT ROW",
+            WindowFrameBoundKind.Following => "FOLLOWING",
+            WindowFrameBoundKind.UnboundedFollowing => "UNBOUNDED FOLLOWING",
+            _ => throw new ArgumentOutOfRangeException(),
+        });
+    }
+
+    private void WriteConnectBy(ConnectByClause connectBy)
+    {
+        if (connectBy.StartWith is not null)
+        {
+            ClauseBreak();
+            Keyword("START WITH");
+            Space();
+            WriteExpression(connectBy.StartWith);
+        }
+
+        ClauseBreak();
+        Keyword("CONNECT BY");
+        if (connectBy.NoCycle)
+        {
+            Space();
+            Keyword("NOCYCLE");
+        }
+
+        Space();
+        WriteExpression(connectBy.Condition);
+    }
+}

--- a/src/Cyqwel/Generation/SqlGenerator.cs
+++ b/src/Cyqwel/Generation/SqlGenerator.cs
@@ -6,7 +6,7 @@ using Cyqwel.Dialects;
 
 namespace Cyqwel.Generation;
 
-public sealed class SqlGenerator
+public sealed partial class SqlGenerator
 {
     private readonly SqlDialect _dialect;
     private readonly SqlGenerationOptions _options;
@@ -43,10 +43,20 @@ public sealed class SqlGenerator
         {
             case SqlDocument value: WriteDocument(value); break;
             case SelectStatement value: WriteSelect(value); break;
+            case ValuesStatement value: WriteValues(value); break;
             case SetOperationStatement value: WriteSetOperation(value); break;
             case InsertStatement value: WriteInsert(value); break;
             case UpdateStatement value: WriteUpdate(value); break;
             case DeleteStatement value: WriteDelete(value); break;
+            case MergeStatement value: WriteMerge(value); break;
+            case CreateTableStatement value: WriteCreateTable(value); break;
+            case AlterTableStatement value: WriteAlterTable(value); break;
+            case DropStatement value: WriteDrop(value); break;
+            case TruncateStatement value: WriteTruncate(value); break;
+            case CreateViewStatement value: WriteCreateView(value); break;
+            case CreateIndexStatement value: WriteCreateIndex(value); break;
+            case CreateSequenceStatement value: WriteCreateSequence(value); break;
+            case AlterSequenceStatement value: WriteAlterSequence(value); break;
             case SqlExpression value: WriteExpression(value); break;
             default: throw new NotSupportedException($"SQL generation does not support '{node.GetType().Name}' as a root node.");
         }
@@ -68,7 +78,7 @@ public sealed class SqlGenerator
 
     private void WriteSelect(SelectStatement select)
     {
-        WriteCommonTableExpressions(select.CommonTableExpressions);
+        WriteCommonTableExpressions(select.CommonTableExpressions, select.IsRecursive);
         Keyword("SELECT");
 
         if (select.IsDistinct)
@@ -143,21 +153,37 @@ public sealed class SqlGenerator
             WriteExpression(select.Having);
         }
 
-        WriteOrderBy(select.OrderBy);
+        if (select.Windows is { Count: > 0 })
+        {
+            ClauseBreak();
+            Keyword("WINDOW");
+            Space();
+            WriteSeparated(select.Windows, WriteWindowDefinition);
+        }
+
+        if (select.Qualify is not null)
+        {
+            ClauseBreak();
+            Keyword("QUALIFY");
+            Space();
+            WriteExpression(select.Qualify);
+        }
+
+        if (select.ConnectBy is not null)
+        {
+            WriteConnectBy(select.ConnectBy);
+        }
+
+        WriteOrderBy(select.OrderBy, select.OrderSiblings);
         if (!limitAsTop) WriteLimitOffset(semanticLimit, select.Offset, select.OrderBy);
     }
 
     private void WriteSetOperation(SetOperationStatement set)
     {
+        WriteCommonTableExpressions(set.CommonTableExpressions, set.IsRecursive);
         WriteQueryOperand(set.Left, set.Operator);
         ClauseBreak();
-        Keyword(set.Operator switch
-        {
-            SetOperator.Union => "UNION",
-            SetOperator.Intersect => "INTERSECT",
-            SetOperator.Except => "EXCEPT",
-            _ => throw new ArgumentOutOfRangeException(nameof(set.Operator)),
-        });
+        Keyword(_dialect.GetSetOperator(set.Operator));
 
         if (set.IsAll)
         {
@@ -166,16 +192,21 @@ public sealed class SqlGenerator
         }
 
         ClauseBreak();
-        WriteQueryOperand(set.Right);
+        WriteQueryOperand(set.Right, set.Operator, isRightOperand: true);
         WriteOrderBy(set.OrderBy);
         WriteLimitOffset(set.Limit, set.Offset, set.OrderBy);
     }
 
-    private void WriteQueryOperand(SqlQuery query, SetOperator? parentOperator = null)
+    private void WriteQueryOperand(
+        SqlQuery query,
+        SetOperator? parentOperator = null,
+        bool isRightOperand = false)
     {
         var parenthesize = query is SetOperationStatement child
             && (parentOperator is null
-                || GetSetOperatorPrecedence(child.Operator) < GetSetOperatorPrecedence(parentOperator.Value));
+                || GetSetOperatorPrecedence(child.Operator) < GetSetOperatorPrecedence(parentOperator.Value)
+                || isRightOperand
+                    && GetSetOperatorPrecedence(child.Operator) == GetSetOperatorPrecedence(parentOperator.Value));
         if (parenthesize)
         {
             _builder.Append('(');
@@ -226,7 +257,7 @@ public sealed class SqlGenerator
             throw new InvalidOperationException("An INSERT statement requires VALUES or a source query.");
         }
 
-        WriteReturning(insert.Returning);
+        WriteReturning(insert.Returning, insert.ReturningInto);
     }
 
     private void WriteUpdate(UpdateStatement update)
@@ -244,6 +275,14 @@ public sealed class SqlGenerator
             WriteExpression(assignment.Value);
         });
 
+        if (update.From is not null)
+        {
+            ClauseBreak();
+            Keyword("FROM");
+            Space();
+            WriteTableSource(update.From);
+        }
+
         if (update.Where is not null)
         {
             ClauseBreak();
@@ -252,7 +291,7 @@ public sealed class SqlGenerator
             WriteExpression(update.Where);
         }
 
-        WriteReturning(update.Returning);
+        WriteReturning(update.Returning, update.ReturningInto);
     }
 
     private void WriteDelete(DeleteStatement delete)
@@ -260,6 +299,14 @@ public sealed class SqlGenerator
         Keyword("DELETE FROM");
         Space();
         WriteNamedTable(delete.Target);
+
+        if (delete.Using is not null)
+        {
+            ClauseBreak();
+            Keyword("USING");
+            Space();
+            WriteTableSource(delete.Using);
+        }
 
         if (delete.Where is not null)
         {
@@ -269,14 +316,21 @@ public sealed class SqlGenerator
             WriteExpression(delete.Where);
         }
 
-        WriteReturning(delete.Returning);
+        WriteReturning(delete.Returning, delete.ReturningInto);
     }
 
-    private void WriteCommonTableExpressions(IReadOnlyList<CommonTableExpression>? expressions)
+    private void WriteCommonTableExpressions(
+        IReadOnlyList<CommonTableExpression>? expressions,
+        bool isRecursive = false)
     {
         if (expressions is not { Count: > 0 }) return;
 
         Keyword("WITH");
+        if (isRecursive)
+        {
+            Space();
+            Keyword("RECURSIVE");
+        }
         Space();
         WriteSeparated(expressions, expression =>
         {
@@ -290,6 +344,13 @@ public sealed class SqlGenerator
 
             Space();
             Keyword("AS");
+            if (expression.Materialization != CteMaterialization.Unspecified)
+            {
+                Space();
+                Keyword(expression.Materialization == CteMaterialization.Materialized
+                    ? "MATERIALIZED"
+                    : "NOT MATERIALIZED");
+            }
             _builder.Append(" (");
             WriteNode(expression.Query);
             _builder.Append(')');
@@ -297,12 +358,12 @@ public sealed class SqlGenerator
         ClauseBreak();
     }
 
-    private void WriteOrderBy(IReadOnlyList<OrderByItem>? orderBy)
+    private void WriteOrderBy(IReadOnlyList<OrderByItem>? orderBy, bool siblings = false)
     {
         if (orderBy is not { Count: > 0 }) return;
 
         ClauseBreak();
-        Keyword("ORDER BY");
+        Keyword(siblings ? "ORDER SIBLINGS BY" : "ORDER BY");
         Space();
         WriteOrderByItems(orderBy);
     }
@@ -391,13 +452,37 @@ public sealed class SqlGenerator
                 }
 
                 break;
+            case SqlLimitStyle.FetchFirst:
+                if (offset is not null)
+                {
+                    ClauseBreak();
+                    Keyword("OFFSET");
+                    Space();
+                    WriteExpression(offset);
+                    Space();
+                    Keyword("ROWS");
+                }
+
+                if (limit is not null)
+                {
+                    ClauseBreak();
+                    Keyword("FETCH FIRST");
+                    Space();
+                    WriteExpression(limit);
+                    Space();
+                    Keyword("ROWS ONLY");
+                }
+
+                break;
 
             default:
                 throw new ArgumentOutOfRangeException();
         }
     }
 
-    private void WriteReturning(IReadOnlyList<SqlExpression>? returning)
+    private void WriteReturning(
+        IReadOnlyList<SqlExpression>? returning,
+        IReadOnlyList<SqlExpression>? into = null)
     {
         if (returning is not { Count: > 0 }) return;
         if (!_dialect.SupportsReturning)
@@ -410,6 +495,19 @@ public sealed class SqlGenerator
         Keyword("RETURNING");
         Space();
         WriteSeparated(returning, expression => WriteExpression(expression));
+        if (into is { Count: > 0 })
+        {
+            if (!_dialect.SupportsReturningInto)
+            {
+                Unsupported($"{_dialect.Name} does not support RETURNING INTO.");
+                if (_options.UnsupportedBehavior == UnsupportedSqlBehavior.Ignore) return;
+            }
+
+            Space();
+            Keyword("INTO");
+            Space();
+            WriteSeparated(into, expression => WriteExpression(expression));
+        }
     }
 
     private void WriteSelectItem(SelectItem item)
@@ -432,9 +530,13 @@ public sealed class SqlGenerator
             case DerivedTable derived:
                 _builder.Append('(');
                 WriteNode(derived.Query);
-                _builder.Append(") ");
-                Keyword("AS");
+                _builder.Append(')');
                 Space();
+                if (_dialect.SupportsTableAliasAs)
+                {
+                    Keyword("AS");
+                    Space();
+                }
                 WriteIdentifier(derived.Alias);
                 break;
             case JoinTable join:
@@ -447,6 +549,11 @@ public sealed class SqlGenerator
                 }
 
                 SpaceOrNewLine();
+                if (join.IsNatural)
+                {
+                    Keyword("NATURAL");
+                    Space();
+                }
                 Keyword(join.Kind switch
                 {
                     JoinKind.Inner => "INNER JOIN",
@@ -465,6 +572,14 @@ public sealed class SqlGenerator
                     Space();
                     WriteExpression(join.Condition);
                 }
+                else if (join.Using is { Count: > 0 })
+                {
+                    Space();
+                    Keyword("USING");
+                    _builder.Append(" (");
+                    WriteSeparated(join.Using, WriteIdentifier);
+                    _builder.Append(')');
+                }
 
                 break;
             default:
@@ -477,8 +592,11 @@ public sealed class SqlGenerator
         WriteTableName(table.Name);
         if (table.Alias is null) return;
         Space();
-        Keyword("AS");
-        Space();
+        if (_dialect.SupportsTableAliasAs)
+        {
+            Keyword("AS");
+            Space();
+        }
         WriteIdentifier(table.Alias);
     }
 
@@ -548,6 +666,63 @@ public sealed class SqlGenerator
                 Space();
                 Keyword(isNull.IsNegated ? "IS NOT NULL" : "IS NULL");
                 break;
+            case BooleanTestExpression booleanTest:
+                WriteExpression(booleanTest.Expression, precedence);
+                Space();
+                Keyword(booleanTest.IsNegated ? "IS NOT" : "IS");
+                Space();
+                Keyword(booleanTest.Kind switch
+                {
+                    BooleanTestKind.True => "TRUE",
+                    BooleanTestKind.False => "FALSE",
+                    BooleanTestKind.Unknown => "UNKNOWN",
+                    _ => throw new ArgumentOutOfRangeException(),
+                });
+                break;
+            case DistinctFromExpression distinct:
+                WriteExpression(distinct.Left, precedence);
+                Space();
+                Keyword(distinct.IsNegated ? "IS NOT DISTINCT FROM" : "IS DISTINCT FROM");
+                Space();
+                WriteExpression(distinct.Right, precedence + 1);
+                break;
+            case RowExpression row:
+                _builder.Append('(');
+                WriteSeparated(row.Values, value => WriteExpression(value));
+                _builder.Append(')');
+                break;
+            case DefaultExpression:
+                Keyword("DEFAULT");
+                break;
+            case CollateExpression collate:
+                WriteExpression(collate.Expression, precedence);
+                Space();
+                Keyword("COLLATE");
+                Space();
+                WriteIdentifier(collate.Collation);
+                break;
+            case ExtractExpression extract:
+                Keyword("EXTRACT");
+                _builder.Append('(');
+                WriteIdentifier(extract.Field);
+                Space();
+                Keyword("FROM");
+                Space();
+                WriteExpression(extract.Expression);
+                _builder.Append(')');
+                break;
+            case IntervalExpression interval:
+                Keyword("INTERVAL");
+                Space();
+                WriteExpression(interval.Value);
+                Space();
+                WriteIdentifier(interval.Unit);
+                break;
+            case SequenceValueExpression sequence:
+                WriteTableName(sequence.Sequence);
+                _builder.Append('.');
+                Keyword(sequence.Kind == SequenceValueKind.Next ? "NEXTVAL" : "CURRVAL");
+                break;
             case FunctionCallExpression function:
                 WriteFunction(function);
                 break;
@@ -579,6 +754,16 @@ public sealed class SqlGenerator
                 WriteDataType(cast.DataType);
                 _builder.Append(')');
                 break;
+            case TryCastExpression cast:
+                Keyword("TRY_CAST");
+                _builder.Append('(');
+                WriteExpression(cast.Expression);
+                Space();
+                Keyword("AS");
+                Space();
+                WriteDataType(cast.DataType);
+                _builder.Append(')');
+                break;
             default:
                 throw new NotSupportedException($"Unsupported SQL expression '{expression.GetType().Name}'.");
         }
@@ -594,6 +779,8 @@ public sealed class SqlGenerator
             UnaryOperator.Minus => "-",
             UnaryOperator.BitwiseNot => "~",
             UnaryOperator.Not => KeywordText("NOT") + " ",
+            UnaryOperator.Prior => KeywordText("PRIOR") + " ",
+            UnaryOperator.ConnectByRoot => KeywordText("CONNECT_BY_ROOT") + " ",
             _ => throw new ArgumentOutOfRangeException(),
         });
         WriteExpression(unary.Operand, GetPrecedence(unary));
@@ -686,6 +873,27 @@ public sealed class SqlGenerator
 
         WriteSeparated(function.Arguments, expression => WriteExpression(expression));
         _builder.Append(')');
+        if (function.WithinGroup is { Count: > 0 })
+        {
+            Space();
+            Keyword("WITHIN GROUP");
+            _builder.Append(" (");
+            Keyword("ORDER BY");
+            Space();
+            WriteOrderByItems(function.WithinGroup);
+            _builder.Append(')');
+        }
+
+        if (function.Filter is not null)
+        {
+            Space();
+            Keyword("FILTER");
+            _builder.Append(" (");
+            Keyword("WHERE");
+            Space();
+            WriteExpression(function.Filter);
+            _builder.Append(')');
+        }
     }
 
     private void WriteWindow(WindowExpression window)
@@ -695,8 +903,14 @@ public sealed class SqlGenerator
         Keyword("OVER");
         _builder.Append(" (");
         var hasClause = false;
+        if (window.WindowName is not null)
+        {
+            WriteIdentifier(window.WindowName);
+            hasClause = true;
+        }
         if (window.PartitionBy is { Count: > 0 })
         {
+            if (hasClause) Space();
             Keyword("PARTITION BY");
             Space();
             WriteSeparated(window.PartitionBy, expression => WriteExpression(expression));
@@ -709,6 +923,13 @@ public sealed class SqlGenerator
             Keyword("ORDER BY");
             Space();
             WriteOrderByItems(window.OrderBy);
+            hasClause = true;
+        }
+
+        if (window.Frame is not null)
+        {
+            if (hasClause) Space();
+            WriteWindowFrame(window.Frame);
         }
 
         _builder.Append(')');
@@ -776,6 +997,13 @@ public sealed class SqlGenerator
 
     private void WriteParameter(ParameterExpression parameter)
     {
+        var rendered = _dialect.RenderParameter(parameter);
+        if (rendered is not null)
+        {
+            _builder.Append(rendered);
+            return;
+        }
+
         if (parameter.Prefix == '?' && parameter.Name.Length == 0)
         {
             _builder.Append('?');
@@ -858,14 +1086,18 @@ public sealed class SqlGenerator
     {
         BinaryExpression { Operator: BinaryOperator.Or } => 1,
         BinaryExpression { Operator: BinaryOperator.And } => 2,
-        BetweenExpression or InExpression or IsNullExpression => 3,
+        BetweenExpression
+            or InExpression
+            or IsNullExpression
+            or BooleanTestExpression
+            or DistinctFromExpression => 3,
         BinaryExpression { Operator: >= BinaryOperator.Equal and <= BinaryOperator.NotILike } => 3,
         BinaryExpression { Operator: BinaryOperator.BitwiseOr or BinaryOperator.BitwiseXor } => 4,
         BinaryExpression { Operator: BinaryOperator.BitwiseAnd } => 5,
         BinaryExpression { Operator: BinaryOperator.Add or BinaryOperator.Subtract or BinaryOperator.Concatenate } => 6,
         BinaryExpression { Operator: BinaryOperator.Multiply or BinaryOperator.Divide or BinaryOperator.Modulo } => 7,
         UnaryExpression => 8,
-        ParenthesizedExpression or WindowExpression => 9,
+        ParenthesizedExpression or WindowExpression or RowExpression => 9,
         _ => 9,
     };
 

--- a/src/Cyqwel/Parsing/SqlDialectParserOptions.cs
+++ b/src/Cyqwel/Parsing/SqlDialectParserOptions.cs
@@ -49,8 +49,12 @@ public sealed record SqlDialectParserOptions
         SupportsOffsetOnly = true,
         SupportsOffsetFetch = true,
         SupportsReturning = true,
+        SupportsReturningInto = true,
         SupportsILike = true,
         SupportsNullOrdering = true,
+        SupportsMinus = true,
+        SupportsRecursiveCte = true,
+        SupportsHierarchicalQueries = true,
         DoublePipeBehavior = SqlDoublePipeBehavior.Concatenate,
     };
 
@@ -78,9 +82,19 @@ public sealed record SqlDialectParserOptions
 
     public bool SupportsReturning { get; init; }
 
+    public bool SupportsReturningInto { get; init; }
+
     public bool SupportsILike { get; init; }
 
     public bool SupportsNullOrdering { get; init; } = true;
+
+    public bool SupportsMinus { get; init; }
+
+    public bool SupportsRecursiveCte { get; init; } = true;
+
+    public bool SupportsHierarchicalQueries { get; init; }
+
+    public bool SupportsTableAliasAs { get; init; } = true;
 
     public SqlDoublePipeBehavior DoublePipeBehavior { get; init; } = SqlDoublePipeBehavior.Concatenate;
 }

--- a/src/Cyqwel/Parsing/SqlParser.cs
+++ b/src/Cyqwel/Parsing/SqlParser.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Cyqwel.Ast;
 using Cyqwel.Dialects;
@@ -55,11 +56,29 @@ public static class SqlParser
         var FETCH = Keyword("FETCH");
         var NEXT = Keyword("NEXT");
         var ONLY = Keyword("ONLY");
+        var UNKNOWN = Keyword("UNKNOWN");
+        var DEFAULT = Keyword("DEFAULT");
+        var COLLATE = Keyword("COLLATE");
+        var EXTRACT = Keyword("EXTRACT");
+        var INTERVAL = Keyword("INTERVAL");
+        var TRY_CAST = Keyword("TRY_CAST");
+        var FILTER = Keyword("FILTER");
+        var WITHIN = Keyword("WITHIN");
+        var WINDOW = Keyword("WINDOW");
+        var RANGE = Keyword("RANGE");
+        var GROUPS = Keyword("GROUPS");
+        var UNBOUNDED = Keyword("UNBOUNDED");
+        var PRECEDING = Keyword("PRECEDING");
+        var CURRENT = Keyword("CURRENT");
+        var FOLLOWING = Keyword("FOLLOWING");
         var UNION = Keyword("UNION");
         var INTERSECT = Keyword("INTERSECT");
         var EXCEPT = Keyword("EXCEPT");
+        var MINUS = Keyword("MINUS");
         var ALL = Keyword("ALL");
         var WITH = Keyword("WITH");
+        var RECURSIVE = Keyword("RECURSIVE");
+        var MATERIALIZED = Keyword("MATERIALIZED");
         var JOIN = Keyword("JOIN");
         var INNER = Keyword("INNER");
         var LEFT = Keyword("LEFT");
@@ -68,6 +87,8 @@ public static class SqlParser
         var CROSS = Keyword("CROSS");
         var OUTER = Keyword("OUTER");
         var ON = Keyword("ON");
+        var USING = Keyword("USING");
+        var NATURAL = Keyword("NATURAL");
         var AND = Keyword("AND");
         var OR = Keyword("OR");
         var NOT = Keyword("NOT");
@@ -93,6 +114,53 @@ public static class SqlParser
         var SET = Keyword("SET");
         var DELETE = Keyword("DELETE");
         var RETURNING = Keyword("RETURNING");
+        var MERGE = Keyword("MERGE");
+        var MATCHED = Keyword("MATCHED");
+        var SOURCE = Keyword("SOURCE");
+        var CONNECT = Keyword("CONNECT");
+        var START = Keyword("START");
+        var NOCYCLE = Keyword("NOCYCLE");
+        var PRIOR = Keyword("PRIOR");
+        var CONNECT_BY_ROOT = Keyword("CONNECT_BY_ROOT");
+        var SIBLINGS = Keyword("SIBLINGS");
+        var CREATE = Keyword("CREATE");
+        var ALTER = Keyword("ALTER");
+        var DROP = Keyword("DROP");
+        var TRUNCATE = Keyword("TRUNCATE");
+        var TABLE = Keyword("TABLE");
+        var TEMPORARY = Keyword("TEMPORARY");
+        var IF = Keyword("IF");
+        var REPLACE = Keyword("REPLACE");
+        var VIEW = Keyword("VIEW");
+        var INDEX = Keyword("INDEX");
+        var UNIQUE = Keyword("UNIQUE");
+        var SEQUENCE = Keyword("SEQUENCE");
+        var COLUMN = Keyword("COLUMN");
+        var CONSTRAINT = Keyword("CONSTRAINT");
+        var PRIMARY = Keyword("PRIMARY");
+        var KEY = Keyword("KEY");
+        var FOREIGN = Keyword("FOREIGN");
+        var REFERENCES = Keyword("REFERENCES");
+        var CHECK = Keyword("CHECK");
+        var CASCADE = Keyword("CASCADE");
+        var RESTRICT = Keyword("RESTRICT");
+        var NO = Keyword("NO");
+        var ACTION = Keyword("ACTION");
+        var RENAME = Keyword("RENAME");
+        var TO = Keyword("TO");
+        var TYPE = Keyword("TYPE");
+        var GENERATED = Keyword("GENERATED");
+        var ALWAYS = Keyword("ALWAYS");
+        var BY_DEFAULT = BY.SkipAnd(DEFAULT);
+        var IDENTITY = Keyword("IDENTITY");
+        var VIRTUAL = Keyword("VIRTUAL");
+        var STORED = Keyword("STORED");
+        var ADD = Keyword("ADD");
+        var CYCLE = Keyword("CYCLE");
+        var CACHE = Keyword("CACHE");
+        var MINVALUE = Keyword("MINVALUE");
+        var MAXVALUE = Keyword("MAXVALUE");
+        var INCREMENT = Keyword("INCREMENT");
 
         var reservedWords = CreateReservedWords(syntax);
 
@@ -127,12 +195,32 @@ public static class SqlParser
         var identifierParts = Separated(dot, simpleIdentifier);
 
         var tableName = identifierParts.Then(parts => new TableName(parts));
-        var column = identifierParts.Then<SqlExpression>(parts => new ColumnExpression(parts));
+        var column = identifierParts.Then<SqlExpression>(parts =>
+        {
+            if (parts.Count > 1
+                && parts[^1].Value.Equals("NEXTVAL", StringComparison.OrdinalIgnoreCase))
+            {
+                return new SequenceValueExpression(
+                    new TableName(parts.Take(parts.Count - 1).ToArray()),
+                    SequenceValueKind.Next);
+            }
+
+            if (parts.Count > 1
+                && parts[^1].Value.Equals("CURRVAL", StringComparison.OrdinalIgnoreCase))
+            {
+                return new SequenceValueExpression(
+                    new TableName(parts.Take(parts.Count - 1).ToArray()),
+                    SequenceValueKind.Current);
+            }
+
+            return new ColumnExpression(parts);
+        });
 
         var expression = Deferred<SqlExpression>();
         var query = Deferred<SqlQuery>();
         var tableSource = Deferred<TableSource>();
         var windowSpecification = Deferred<ParsedWindow>();
+        var withinGroupOrderBy = Deferred<IReadOnlyList<OrderByItem>>();
 
         var number = Terms.Decimal().Then<SqlExpression>(value =>
             decimal.Truncate(value) == value
@@ -161,21 +249,37 @@ public static class SqlParser
         var functionArguments = DISTINCT.Optional()
             .And(argumentList.Or(Always<IReadOnlyList<SqlExpression>>(Array.Empty<SqlExpression>())))
             .Then(value => new ParsedFunctionArguments(value.Item2, value.Item1.HasValue));
-        var function = simpleIdentifier
+        var functionCore = simpleIdentifier
             .And(Between(leftParenthesis, functionArguments, rightParenthesis))
+            .Then(value => new FunctionCallExpression(
+                value.Item1,
+                value.Item2.Arguments,
+                value.Item2.IsDistinct));
+        var withinGroup = WITHIN.SkipAnd(GROUP)
+            .SkipAnd(Between(leftParenthesis, withinGroupOrderBy, rightParenthesis));
+        var functionFilter = FILTER.SkipAnd(Between(
+            leftParenthesis,
+            WHERE.SkipAnd(expression),
+            rightParenthesis));
+        var function = functionCore
+            .And(withinGroup.Optional())
+            .And(functionFilter.Optional())
             .And(OVER.SkipAnd(Between(leftParenthesis, windowSpecification, rightParenthesis)).Optional())
             .Then<SqlExpression>(value =>
             {
-                SqlExpression result = new FunctionCallExpression(
-                    value.Item1,
-                    value.Item2.Arguments,
-                    value.Item2.IsDistinct);
-                return value.Item3.HasValue
+                var call = value.Item1 with
+                {
+                    WithinGroup = value.Item2.HasValue ? value.Item2.Value : null,
+                    Filter = value.Item3.HasValue ? value.Item3.Value : null,
+                };
+                return value.Item4.HasValue
                     ? new WindowExpression(
-                        result,
-                        value.Item3.Value.PartitionBy,
-                        value.Item3.Value.OrderBy)
-                    : result;
+                        call,
+                        value.Item4.Value.PartitionBy,
+                        value.Item4.Value.OrderBy,
+                        value.Item4.Value.Frame,
+                        value.Item4.Value.WindowName)
+                    : call;
             });
 
         var dataTypeArguments = Between(
@@ -192,6 +296,21 @@ public static class SqlParser
             .And(dataType)
             .AndSkip(rightParenthesis)
             .Then<SqlExpression>(value => new CastExpression(value.Item1, value.Item2));
+        var tryCast = TRY_CAST.SkipAnd(leftParenthesis)
+            .SkipAnd(expression)
+            .AndSkip(AS)
+            .And(dataType)
+            .AndSkip(rightParenthesis)
+            .Then<SqlExpression>(value => new TryCastExpression(value.Item1, value.Item2));
+        var extract = EXTRACT.SkipAnd(leftParenthesis)
+            .SkipAnd(simpleIdentifier)
+            .AndSkip(FROM)
+            .And(expression)
+            .AndSkip(rightParenthesis)
+            .Then<SqlExpression>(value => new ExtractExpression(value.Item1, value.Item2));
+        var interval = INTERVAL.SkipAnd(text.Or(number).Or(parameter))
+            .And(simpleIdentifier)
+            .Then<SqlExpression>(value => new IntervalExpression(value.Item1, value.Item2));
 
         var whenClause = WHEN.SkipAnd(expression)
             .AndSkip(THEN)
@@ -211,36 +330,58 @@ public static class SqlParser
             .Then<SqlExpression>(value => new ExistsExpression(value.Item2, value.Item1.HasValue));
         var subquery = Between(leftParenthesis, query, rightParenthesis)
             .Then<SqlExpression>(value => new SubqueryExpression(value));
+        var row = ROW.SkipAnd(Between(leftParenthesis, Separated(comma, expression), rightParenthesis))
+            .Then<SqlExpression>(values => new RowExpression(values));
         var grouped = Between(leftParenthesis, expression, rightParenthesis)
             .Then<SqlExpression>(value => new ParenthesizedExpression(value));
         var qualifiedStar = simpleIdentifier.AndSkip(dot).AndSkip(star)
             .Then<SqlExpression>(qualifier => new StarExpression([qualifier]));
         var starExpression = star.Then<SqlExpression>(new StarExpression());
 
-        var term = cast
+        var defaultExpression = DEFAULT.Then<SqlExpression>(new DefaultExpression());
+        var term = tryCast
+            .Or(cast)
+            .Or(extract)
+            .Or(interval)
             .Or(caseExpression)
             .Or(exists)
             .Or(subquery)
             .Or(function)
+            .Or(row)
             .Or(grouped)
             .Or(qualifiedStar)
             .Or(starExpression)
             .Or(parameter)
             .Or(boolean)
             .Or(nullLiteral)
+            .Or(defaultExpression)
             .Or(text)
             .Or(number)
             .Or(column);
 
-        var unary = Terms.Char('-').And(term)
+        Parser<SqlExpression> unary = Terms.Char('-').And(term)
             .Then<SqlExpression>(value => new UnaryExpression(UnaryOperator.Minus, value.Item2))
             .Or(Terms.Char('+').And(term)
                 .Then<SqlExpression>(value => new UnaryExpression(UnaryOperator.Plus, value.Item2)))
             .Or(Terms.Char('~').And(term)
                 .Then<SqlExpression>(value => new UnaryExpression(UnaryOperator.BitwiseNot, value.Item2)));
-        var primary = unary.Or(term);
+        if (syntax.SupportsHierarchicalQueries)
+        {
+            unary = PRIOR.SkipAnd(term)
+                .Then<SqlExpression>(value => new UnaryExpression(UnaryOperator.Prior, value))
+                .Or(CONNECT_BY_ROOT.SkipAnd(term)
+                    .Then<SqlExpression>(value => new UnaryExpression(UnaryOperator.ConnectByRoot, value)))
+                .Or(unary);
+        }
 
-        var multiplicative = primary.LeftAssociative(
+        var primary = unary.Or(term);
+        var collated = primary
+            .And(COLLATE.SkipAnd(simpleIdentifier).Optional())
+            .Then<SqlExpression>(value => value.Item2.HasValue
+                ? new CollateExpression(value.Item1, value.Item2.Value)
+                : value.Item1);
+
+        var multiplicative = collated.LeftAssociative(
             (Terms.Char('*'), (left, right) => new BinaryExpression(left, BinaryOperator.Multiply, right)),
             (Terms.Char('/'), (left, right) => new BinaryExpression(left, BinaryOperator.Divide, right)),
             (Terms.Char('%'), (left, right) => new BinaryExpression(left, BinaryOperator.Modulo, right)));
@@ -302,6 +443,19 @@ public static class SqlParser
             .AndSkip(NULL)
             .Then<Func<SqlExpression, SqlExpression>>(negated =>
                 target => new IsNullExpression(target, negated.HasValue));
+        var booleanTestKind = TRUE.Then(BooleanTestKind.True)
+            .Or(FALSE.Then(BooleanTestKind.False))
+            .Or(UNKNOWN.Then(BooleanTestKind.Unknown));
+        var booleanTestSuffix = IS.SkipAnd(NOT.Optional())
+            .And(booleanTestKind)
+            .Then<Func<SqlExpression, SqlExpression>>(value =>
+                target => new BooleanTestExpression(target, value.Item2, value.Item1.HasValue));
+        var distinctFromSuffix = IS.SkipAnd(NOT.Optional())
+            .AndSkip(DISTINCT)
+            .AndSkip(FROM)
+            .And(bitwise)
+            .Then<Func<SqlExpression, SqlExpression>>(value =>
+                target => new DistinctFromExpression(target, value.Item2, value.Item1.HasValue));
 
         Parser<string> likeKeyword = LIKE;
         if (syntax.SupportsILike)
@@ -320,6 +474,8 @@ public static class SqlParser
         var predicateSuffix = betweenSuffix
             .Or(inSuffix)
             .Or(isNullSuffix)
+            .Or(booleanTestSuffix)
+            .Or(distinctFromSuffix)
             .Or(likeSuffix);
         var predicate = bitwise.And(predicateSuffix.Optional())
             .Then<SqlExpression>(value =>
@@ -356,13 +512,46 @@ public static class SqlParser
                 value.Item3.HasValue ? value.Item3.Value : NullOrder.Unspecified));
         var windowPartitionBy = PARTITION.SkipAnd(BY).SkipAnd(Separated(comma, expression));
         var windowOrderBy = ORDER.SkipAnd(BY).SkipAnd(Separated(comma, windowOrderItem));
+        withinGroupOrderBy.Parser = windowOrderBy;
+        var unboundedPreceding = UNBOUNDED.SkipAnd(PRECEDING)
+            .Then(new WindowFrameBound(WindowFrameBoundKind.UnboundedPreceding));
+        var offsetPreceding = expression.AndSkip(PRECEDING)
+            .Then(value => new WindowFrameBound(WindowFrameBoundKind.Preceding, value));
+        var currentRow = CURRENT.SkipAnd(ROW)
+            .Then(new WindowFrameBound(WindowFrameBoundKind.CurrentRow));
+        var offsetFollowing = expression.AndSkip(FOLLOWING)
+            .Then(value => new WindowFrameBound(WindowFrameBoundKind.Following, value));
+        var unboundedFollowing = UNBOUNDED.SkipAnd(FOLLOWING)
+            .Then(new WindowFrameBound(WindowFrameBoundKind.UnboundedFollowing));
+        var windowFrameBound = unboundedPreceding
+            .Or(currentRow)
+            .Or(unboundedFollowing)
+            .Or(offsetPreceding)
+            .Or(offsetFollowing);
+        var windowFrameUnit = ROWS.Then(WindowFrameUnit.Rows)
+            .Or(RANGE.Then(WindowFrameUnit.Range))
+            .Or(GROUPS.Then(WindowFrameUnit.Groups));
+        var betweenFrame = BETWEEN.SkipAnd(windowFrameBound)
+            .AndSkip(AND)
+            .And(windowFrameBound);
+        var windowFrame = windowFrameUnit
+            .And(betweenFrame
+                .Then(value => (Start: value.Item1, End: (WindowFrameBound?)value.Item2))
+                .Or(windowFrameBound.Then(value => (Start: value, End: (WindowFrameBound?)null))))
+            .Then(value => new WindowFrame(value.Item1, value.Item2.Start, value.Item2.End));
         windowSpecification.Parser = windowPartitionBy.Optional()
             .And(windowOrderBy.Optional())
+            .And(windowFrame.Optional())
             .Then(value => new ParsedWindow(
                 value.Item1.HasValue ? value.Item1.Value : null,
-                value.Item2.HasValue ? value.Item2.Value : null));
+                value.Item2.HasValue ? value.Item2.Value : null,
+                value.Item3.HasValue ? value.Item3.Value : null,
+                null));
 
         var alias = AS.SkipAnd(simpleIdentifier).Or(nonKeywordIdentifier);
+        var tableAlias = syntax.SupportsTableAliasAs
+            ? alias
+            : nonKeywordIdentifier;
         var selectItem = expression.And(alias.Optional())
             .Then(value => new SelectItem(
                 value.Item1,
@@ -370,9 +559,9 @@ public static class SqlParser
         var projections = Separated(comma, selectItem);
 
         var derivedTable = Between(leftParenthesis, query, rightParenthesis)
-            .And(AS.Optional().SkipAnd(nonKeywordIdentifier))
+            .And(tableAlias)
             .Then<TableSource>(value => new DerivedTable(value.Item1, value.Item2));
-        var namedTable = tableName.And(alias.Optional())
+        var namedTable = tableName.And(tableAlias.Optional())
             .Then<TableSource>(value => new NamedTable(
                 value.Item1,
                 value.Item2.HasValue ? value.Item2.Value : null));
@@ -384,14 +573,20 @@ public static class SqlParser
             .Or(CROSS.AndSkip(JOIN).Then(JoinKind.Cross))
             .Or(INNER.AndSkip(JOIN).Then(JoinKind.Inner))
             .Or(JOIN.Then(JoinKind.Inner));
-        var join = joinKind.And(tablePrimary).And(ON.SkipAnd(expression).Optional())
+        var joinCondition = ON.SkipAnd(expression)
+            .Then(value => new ParsedJoinCondition(value, null))
+            .Or(USING.SkipAnd(Between(leftParenthesis, Separated(comma, simpleIdentifier), rightParenthesis))
+                .Then(value => new ParsedJoinCondition(null, value)));
+        var join = NATURAL.Optional().And(joinKind).And(tablePrimary).And(joinCondition.Optional())
             .Then(value => new ParsedJoin(
-                value.Item1,
                 value.Item2,
-                value.Item3.HasValue ? value.Item3.Value : null,
-                JoinSyntax.Explicit));
+                value.Item3,
+                value.Item4.HasValue ? value.Item4.Value.Condition : null,
+                JoinSyntax.Explicit,
+                value.Item4.HasValue ? value.Item4.Value.Using : null,
+                value.Item1.HasValue));
         var commaTable = comma.SkipAnd(tablePrimary)
-            .Then(value => new ParsedJoin(JoinKind.Cross, value, null, JoinSyntax.Comma));
+            .Then(value => new ParsedJoin(JoinKind.Cross, value, null, JoinSyntax.Comma, null, false));
         tableSource.Parser = tablePrimary.And(ZeroOrMany(join.Or(commaTable)))
             .Then(value =>
             {
@@ -403,7 +598,9 @@ public static class SqlParser
                         parsedJoin.Right,
                         parsedJoin.Kind,
                         parsedJoin.Condition,
-                        parsedJoin.Syntax);
+                        parsedJoin.Syntax,
+                        parsedJoin.Using,
+                        parsedJoin.IsNatural);
                 }
 
                 return result;
@@ -414,7 +611,10 @@ public static class SqlParser
                 value.Item1,
                 value.Item2.HasValue ? value.Item2.Value : OrderDirection.Unspecified,
                 value.Item3.HasValue ? value.Item3.Value : NullOrder.Unspecified));
-        var orderBy = ORDER.SkipAnd(BY).SkipAnd(Separated(comma, orderItem));
+        var orderBy = ORDER.SkipAnd(SIBLINGS.Optional())
+            .AndSkip(BY)
+            .And(Separated(comma, orderItem))
+            .Then(value => new ParsedOrderBy(value.Item2, value.Item1.HasValue));
 
         var limit = LIMIT.SkipAnd(expression)
             .And(OFFSET.SkipAnd(expression).Optional())
@@ -439,10 +639,20 @@ public static class SqlParser
             .Then(value => new RowLimit(
                 value.Item2.HasValue ? value.Item2.Value : null,
                 value.Item1));
+        var fetchOnly = FETCH
+            .SkipAnd(NEXT.Or(FIRST))
+            .SkipAnd(expression)
+            .AndSkip(rowOrRows)
+            .AndSkip(ONLY)
+            .Then(value => new RowLimit(value, null));
         var rowLimitParsers = new List<Parser<RowLimit>>(4);
         if (syntax.SupportsLimitComma) rowLimitParsers.Add(limitComma);
         if (syntax.SupportsLimit) rowLimitParsers.Add(limit);
-        if (syntax.SupportsOffsetFetch) rowLimitParsers.Add(offsetFetch);
+        if (syntax.SupportsOffsetFetch)
+        {
+            rowLimitParsers.Add(offsetFetch);
+            rowLimitParsers.Add(fetchOnly);
+        }
         if (syntax.SupportsOffsetOnly) rowLimitParsers.Add(offsetOnly);
         Parser<RowLimit?> rowLimit = rowLimitParsers.Count == 0
             ? Always<RowLimit?>(null)
@@ -460,46 +670,86 @@ public static class SqlParser
             : Always<ParsedTop?>(null);
         var from = FROM.SkipAnd(tableSource);
         var groupBy = GROUP.SkipAnd(BY).SkipAnd(Separated(comma, expression));
+        var windowDefinition = simpleIdentifier
+            .AndSkip(AS)
+            .And(Between(leftParenthesis, windowSpecification, rightParenthesis))
+            .Then(value => new WindowDefinition(
+                value.Item1,
+                value.Item2.WindowName,
+                value.Item2.PartitionBy,
+                value.Item2.OrderBy,
+                value.Item2.Frame));
+        var windows = WINDOW.SkipAnd(Separated(comma, windowDefinition));
+        var connectBy = syntax.SupportsHierarchicalQueries
+            ? START.SkipAnd(WITH).SkipAnd(expression).Optional()
+                .And(CONNECT.SkipAnd(BY).SkipAnd(NOCYCLE.Optional()).And(expression))
+                .Then(value => new ConnectByClause(
+                    value.Item2.Item2,
+                    value.Item1.HasValue ? value.Item1.Value : null,
+                    value.Item2.Item1.HasValue))
+                .Then<ConnectByClause?>(value => value)
+                .Or(Always<ConnectByClause?>(null))
+            : Always<ConnectByClause?>(null);
 
-        var selectCore = SELECT.SkipAnd(DISTINCT.Optional())
+        var selectHead = SELECT.SkipAnd(DISTINCT.Optional())
             .And(top)
             .And(projections)
             .And(from.Optional())
             .And(WHERE.SkipAnd(expression).Optional())
             .And(groupBy.Optional())
             .And(HAVING.SkipAnd(expression).Optional())
+            .Then(value => new ParsedSelectHead(
+                value.Item1.HasValue,
+                value.Item2,
+                value.Item3,
+                value.Item4.HasValue ? value.Item4.Value : null,
+                value.Item5.HasValue ? value.Item5.Value : null,
+                value.Item6.HasValue ? value.Item6.Value : null,
+                value.Item7.HasValue ? value.Item7.Value : null));
+        var selectCore = selectHead
+            .And(windows.Optional())
+            .And(Keyword("QUALIFY").SkipAnd(expression).Optional())
+            .And(connectBy)
             .Then(value =>
             {
-                var (distinct, parsedTop, items, parsedFrom, parsedWhere, parsedGroupBy, parsedHaving) = value;
+                var (head, parsedWindows, parsedQualify, parsedConnectBy) = value;
                 return new SelectStatement(
-                    items,
-                    parsedFrom.HasValue ? parsedFrom.Value : null,
-                    parsedWhere.HasValue ? parsedWhere.Value : null,
-                    parsedGroupBy.HasValue ? parsedGroupBy.Value : null,
-                    parsedHaving.HasValue ? parsedHaving.Value : null,
-                    IsDistinct: distinct.HasValue,
-                    Top: parsedTop?.Expression,
-                    IsTopPercent: parsedTop?.IsPercent ?? false,
-                    WithTies: parsedTop?.WithTies ?? false);
+                    head.Items,
+                    head.From,
+                    head.Where,
+                    head.GroupBy,
+                    head.Having,
+                    IsDistinct: head.IsDistinct,
+                    Top: head.Top?.Expression,
+                    IsTopPercent: head.Top?.IsPercent ?? false,
+                    WithTies: head.Top?.WithTies ?? false,
+                    Windows: parsedWindows.HasValue ? parsedWindows.Value : null,
+                    Qualify: parsedQualify.HasValue ? parsedQualify.Value : null,
+                    ConnectBy: parsedConnectBy);
             });
 
         var setOperator = UNION.Then(SetOperator.Union)
             .Or(INTERSECT.Then(SetOperator.Intersect))
             .Or(EXCEPT.Then(SetOperator.Except));
-        var setTail = setOperator.And(ALL.Optional()).And(selectCore)
+        if (syntax.SupportsMinus)
+        {
+            setOperator = MINUS.Then(SetOperator.Except).Or(setOperator);
+        }
+
+        var valueRow = Between(leftParenthesis, Separated(comma, expression), rightParenthesis);
+        var valuesCore = VALUES.SkipAnd(Separated(comma, valueRow))
+            .Then<SqlQuery>(rows => new ValuesStatement(rows));
+        var queryPrimary = selectCore.Then<SqlQuery>(value => value).Or(valuesCore);
+        var setTail = setOperator.And(ALL.Optional()).And(queryPrimary)
             .Then(value => new SetTail(value.Item1, value.Item3, value.Item2.HasValue));
 
-        var queryBody = selectCore
+        var queryBody = queryPrimary
             .And(ZeroOrMany(setTail))
             .And(orderBy.Optional())
             .And(rowLimit)
             .Then(value =>
             {
-                SqlQuery result = value.Item1;
-                foreach (var tail in value.Item2)
-                {
-                    result = new SetOperationStatement(result, tail.Operator, tail.Right, tail.IsAll);
-                }
+                var result = BuildSetOperation(value.Item1, value.Item2);
 
                 var parsedOrderBy = value.Item3.HasValue ? value.Item3.Value : null;
                 var parsedLimit = value.Item4;
@@ -507,29 +757,45 @@ public static class SqlParser
             });
 
         var cteColumns = Between(leftParenthesis, Separated(comma, simpleIdentifier), rightParenthesis);
+        var materialization = NOT.SkipAnd(MATERIALIZED).Then(CteMaterialization.NotMaterialized)
+            .Or(MATERIALIZED.Then(CteMaterialization.Materialized));
         var cte = simpleIdentifier
             .And(cteColumns.Optional())
             .AndSkip(AS)
+            .And(materialization.Optional())
             .And(Between(leftParenthesis, query, rightParenthesis))
             .Then(value => new CommonTableExpression(
                 value.Item1,
-                value.Item3,
-                value.Item2.HasValue ? value.Item2.Value : null));
-        var with = WITH.SkipAnd(Separated(comma, cte));
+                value.Item4,
+                value.Item2.HasValue ? value.Item2.Value : null,
+                value.Item3.HasValue ? value.Item3.Value : CteMaterialization.Unspecified));
+        Parser<bool> recursive = syntax.SupportsRecursiveCte
+            ? RECURSIVE.Optional().Then(value => value.HasValue)
+            : Always(false);
+        var with = WITH.SkipAnd(recursive)
+            .And(Separated(comma, cte))
+            .Then(value => new ParsedWith(value.Item2, value.Item1));
 
         query.Parser = with.Optional().And(queryBody)
             .Then(value => value.Item1.HasValue
-                ? ApplyCommonTableExpressions(value.Item2, value.Item1.Value)
+                ? ApplyCommonTableExpressions(
+                    value.Item2,
+                    value.Item1.Value.Expressions,
+                    value.Item1.Value.IsRecursive)
                 : value.Item2);
 
-        var parsedReturning = RETURNING.SkipAnd(Separated(comma, expression));
-        Parser<IReadOnlyList<SqlExpression>?> returning = syntax.SupportsReturning
+        var parsedReturning = RETURNING.SkipAnd(Separated(comma, expression))
+            .And(INTO.SkipAnd(Separated(comma, expression)).Optional())
+            .Then(value => new ParsedReturning(
+                value.Item1,
+                value.Item2.HasValue ? value.Item2.Value : null));
+        Parser<ParsedReturning?> returning = syntax.SupportsReturning
             ? parsedReturning
-                .Then<IReadOnlyList<SqlExpression>?>(value => value)
-                .Or(Always<IReadOnlyList<SqlExpression>?>(null))
-            : Always<IReadOnlyList<SqlExpression>?>(null);
+                .When((_, value) => value.Into is null || syntax.SupportsReturningInto)
+                .Then<ParsedReturning?>(value => value)
+                .Or(Always<ParsedReturning?>(null))
+            : Always<ParsedReturning?>(null);
         var insertColumns = Between(leftParenthesis, Separated(comma, simpleIdentifier), rightParenthesis);
-        var valueRow = Between(leftParenthesis, Separated(comma, expression), rightParenthesis);
         var insertValues = VALUES.SkipAnd(Separated(comma, valueRow));
         var insert = INSERT.SkipAnd(INTO)
             .SkipAnd(tableName)
@@ -543,34 +809,394 @@ public static class SqlParser
                 value.Item2.HasValue ? value.Item2.Value : null,
                 value.Item3.HasValue ? value.Item3.Value : null,
                 value.Item4.HasValue ? value.Item4.Value : null,
-                value.Item5));
+                value.Item5?.Expressions,
+                value.Item5?.Into));
 
         var assignment = column.AndSkip(Terms.Char('=')).And(expression)
             .Then(value => new Assignment((ColumnExpression)value.Item1, value.Item2));
         var update = UPDATE.SkipAnd(namedTable)
             .AndSkip(SET)
             .And(Separated(comma, assignment))
+            .And(FROM.SkipAnd(tableSource).Optional())
             .And(WHERE.SkipAnd(expression).Optional())
             .And(returning)
             .Then<SqlStatement>(value => new UpdateStatement(
                 (NamedTable)value.Item1,
                 value.Item2,
-                value.Item3.HasValue ? value.Item3.Value : null,
-                value.Item4));
+                value.Item4.HasValue ? value.Item4.Value : null,
+                value.Item5?.Expressions,
+                value.Item5?.Into,
+                value.Item3.HasValue ? value.Item3.Value : null));
 
         var delete = DELETE.SkipAnd(FROM)
             .SkipAnd(namedTable)
+            .And(USING.SkipAnd(tableSource).Optional())
             .And(WHERE.SkipAnd(expression).Optional())
             .And(returning)
             .Then<SqlStatement>(value => new DeleteStatement(
                 (NamedTable)value.Item1,
-                value.Item2.HasValue ? value.Item2.Value : null,
-                value.Item3));
+                value.Item3.HasValue ? value.Item3.Value : null,
+                value.Item4?.Expressions,
+                value.Item4?.Into,
+                value.Item2.HasValue ? value.Item2.Value : null));
+
+        var mergeUpdate = UPDATE.SkipAnd(SET)
+            .SkipAnd(Separated(comma, assignment))
+            .And(DELETE.SkipAnd(WHERE).SkipAnd(expression).Optional())
+            .Then<MergeAction>(value => new MergeUpdateAction(
+                value.Item1,
+                value.Item2.HasValue ? value.Item2.Value : null));
+        var mergeInsert = INSERT
+            .SkipAnd(insertColumns.Optional())
+            .AndSkip(VALUES)
+            .And(valueRow)
+            .Then<MergeAction>(value => new MergeInsertAction(
+                value.Item1.HasValue ? value.Item1.Value : null,
+                value.Item2));
+        var mergeDelete = DELETE.Then<MergeAction>(new MergeDeleteAction());
+        var mergeMatchKind = MATCHED.Then(MergeMatchKind.Matched)
+            .Or(NOT.SkipAnd(MATCHED)
+                .And(BY.SkipAnd(SOURCE).Optional())
+                .Then(value => value.Item2.HasValue
+                    ? MergeMatchKind.NotMatchedBySource
+                    : MergeMatchKind.NotMatched));
+        var mergeWhen = WHEN.SkipAnd(mergeMatchKind)
+            .And(AND.SkipAnd(expression).Optional())
+            .AndSkip(THEN)
+            .And(mergeUpdate.Or(mergeInsert).Or(mergeDelete))
+            .Then(value => new MergeWhenClause(
+                value.Item1,
+                value.Item3,
+                value.Item2.HasValue ? value.Item2.Value : null));
+        var merge = MERGE.SkipAnd(INTO)
+            .SkipAnd(namedTable)
+            .AndSkip(USING)
+            .And(tableSource)
+            .AndSkip(ON)
+            .And(expression)
+            .And(OneOrMany(mergeWhen))
+            .And(returning)
+            .Then<SqlStatement>(value => new MergeStatement(
+                (NamedTable)value.Item1,
+                value.Item2,
+                value.Item3,
+                value.Item4,
+                value.Item5?.Expressions,
+                value.Item5?.Into));
+
+        var columnModifier = DEFAULT.SkipAnd(expression)
+            .Then(value => new ParsedColumnModifier(ParsedColumnModifierKind.Default, value))
+            .Or(GENERATED.SkipAnd(ALWAYS)
+                .SkipAnd(AS)
+                .SkipAnd(IDENTITY)
+                .Then(new ParsedColumnModifier(
+                    ParsedColumnModifierKind.Identity,
+                    Identity: IdentityGeneration.Always)))
+            .Or(GENERATED.SkipAnd(BY_DEFAULT)
+                .SkipAnd(AS)
+                .SkipAnd(IDENTITY)
+                .Then(new ParsedColumnModifier(
+                    ParsedColumnModifierKind.Identity,
+                    Identity: IdentityGeneration.ByDefault)))
+            .Or(GENERATED.SkipAnd(ALWAYS)
+                .SkipAnd(AS)
+                .SkipAnd(Between(leftParenthesis, expression, rightParenthesis))
+                .And(STORED.Then(GeneratedColumnKind.Stored)
+                    .Or(VIRTUAL.Then(GeneratedColumnKind.Virtual))
+                    .Optional())
+                .Then(value => new ParsedColumnModifier(
+                    ParsedColumnModifierKind.Generated,
+                    value.Item1,
+                    value.Item2.HasValue ? value.Item2.Value : GeneratedColumnKind.Virtual)))
+            .Or(NOT.SkipAnd(NULL)
+                .Then(new ParsedColumnModifier(ParsedColumnModifierKind.NotNull)))
+            .Or(NULL.Then(new ParsedColumnModifier(ParsedColumnModifierKind.Null)))
+            .Or(PRIMARY.SkipAnd(KEY)
+                .Then(new ParsedColumnModifier(ParsedColumnModifierKind.PrimaryKey)))
+            .Or(UNIQUE.Then(new ParsedColumnModifier(ParsedColumnModifierKind.Unique)))
+            .Or(IDENTITY.Then(new ParsedColumnModifier(
+                ParsedColumnModifierKind.Identity,
+                Identity: IdentityGeneration.ByDefault)));
+        var columnDefinition = simpleIdentifier
+            .And(dataType)
+            .And(ZeroOrMany(columnModifier))
+            .Then(value =>
+            {
+                var nullability = Nullability.Unspecified;
+                SqlExpression? defaultValue = null;
+                SqlExpression? generated = null;
+                var generatedKind = GeneratedColumnKind.Virtual;
+                var identity = IdentityGeneration.None;
+                var isPrimaryKey = false;
+                var isUnique = false;
+                foreach (var modifier in value.Item3)
+                {
+                    if (modifier.Kind == ParsedColumnModifierKind.Null)
+                    {
+                        nullability = Nullability.Null;
+                    }
+                    else if (modifier.Kind == ParsedColumnModifierKind.NotNull)
+                    {
+                        nullability = Nullability.NotNull;
+                    }
+                    else if (modifier.Kind == ParsedColumnModifierKind.Default)
+                    {
+                        defaultValue = modifier.Expression;
+                    }
+                    else if (modifier.Kind == ParsedColumnModifierKind.Generated)
+                    {
+                        generated = modifier.Expression;
+                        generatedKind = modifier.GeneratedKind;
+                    }
+                    else if (modifier.Kind == ParsedColumnModifierKind.Identity)
+                    {
+                        identity = modifier.Identity;
+                    }
+                    else if (modifier.Kind == ParsedColumnModifierKind.PrimaryKey)
+                    {
+                        isPrimaryKey = true;
+                    }
+                    else
+                    {
+                        isUnique = true;
+                    }
+                }
+
+                return new ColumnDefinition(
+                    value.Item1,
+                    value.Item2,
+                    nullability,
+                    defaultValue,
+                    generated,
+                    generatedKind,
+                    identity,
+                    isPrimaryKey,
+                    isUnique);
+            });
+
+        var identifierList = Between(
+            leftParenthesis,
+            Separated(comma, simpleIdentifier),
+            rightParenthesis);
+        var constraintName = CONSTRAINT.SkipAnd(simpleIdentifier).Optional();
+        var primaryKeyConstraint = constraintName
+            .And(PRIMARY.SkipAnd(KEY).SkipAnd(identifierList))
+            .Then<TableConstraint>(value => new PrimaryKeyConstraint(
+                value.Item2,
+                value.Item1.HasValue ? value.Item1.Value : null));
+        var uniqueConstraint = constraintName
+            .And(UNIQUE.SkipAnd(identifierList))
+            .Then<TableConstraint>(value => new UniqueConstraint(
+                value.Item2,
+                value.Item1.HasValue ? value.Item1.Value : null));
+        var foreignKeyConstraint = constraintName
+            .And(FOREIGN.SkipAnd(KEY).SkipAnd(identifierList))
+            .AndSkip(REFERENCES)
+            .And(tableName)
+            .And(identifierList)
+            .Then<TableConstraint>(value => new ForeignKeyConstraint(
+                value.Item2,
+                value.Item3,
+                value.Item4,
+                ReferentialAction.Unspecified,
+                ReferentialAction.Unspecified,
+                value.Item1.HasValue ? value.Item1.Value : null));
+        var checkConstraint = constraintName
+            .And(CHECK.SkipAnd(Between(leftParenthesis, expression, rightParenthesis)))
+            .Then<TableConstraint>(value => new CheckConstraint(
+                value.Item2,
+                value.Item1.HasValue ? value.Item1.Value : null));
+        var tableConstraint = primaryKeyConstraint
+            .Or(uniqueConstraint)
+            .Or(foreignKeyConstraint)
+            .Or(checkConstraint);
+        var tableElement = tableConstraint.Then<TableElement>(value => value)
+            .Or(columnDefinition.Then<TableElement>(value => value));
+        var tableElements = Between(
+            leftParenthesis,
+            Separated(comma, tableElement),
+            rightParenthesis);
+        var ifNotExists = IF.SkipAnd(NOT).SkipAnd(EXISTS).Optional();
+        var createTable = CREATE.SkipAnd(TEMPORARY.Optional())
+            .AndSkip(TABLE)
+            .And(ifNotExists)
+            .And(tableName)
+            .And(tableElements.Optional())
+            .And(AS.SkipAnd(query).Optional())
+            .Then<SqlStatement>(value => new CreateTableStatement(
+                value.Item3,
+                value.Item4.HasValue ? value.Item4.Value : Array.Empty<TableElement>(),
+                value.Item2.HasValue,
+                value.Item1.HasValue,
+                value.Item5.HasValue ? value.Item5.Value : null));
+
+        var createView = CREATE.SkipAnd(OR.SkipAnd(REPLACE).Optional())
+            .And(TEMPORARY.Optional())
+            .AndSkip(VIEW)
+            .And(tableName)
+            .And(identifierList.Optional())
+            .AndSkip(AS)
+            .And(query)
+            .Then<SqlStatement>(value => new CreateViewStatement(
+                value.Item3,
+                value.Item5,
+                value.Item4.HasValue ? value.Item4.Value : null,
+                value.Item1.HasValue,
+                value.Item2.HasValue));
+
+        var indexColumn = expression.And(orderDirection.Optional()).And(nullOrder.Optional())
+            .Then(value => new IndexColumn(
+                value.Item1,
+                value.Item2.HasValue ? value.Item2.Value : OrderDirection.Unspecified,
+                value.Item3.HasValue ? value.Item3.Value : NullOrder.Unspecified));
+        var createIndex = CREATE.SkipAnd(UNIQUE.Optional())
+            .AndSkip(INDEX)
+            .And(ifNotExists)
+            .And(tableName)
+            .AndSkip(ON)
+            .And(tableName)
+            .And(Between(leftParenthesis, Separated(comma, indexColumn), rightParenthesis))
+            .And(WHERE.SkipAnd(expression).Optional())
+            .Then<SqlStatement>(value => new CreateIndexStatement(
+                value.Item3,
+                value.Item4,
+                value.Item5,
+                value.Item1.HasValue,
+                value.Item2.HasValue,
+                value.Item6.HasValue ? value.Item6.Value : null));
+
+        var sequenceOption = START.SkipAnd(WITH).SkipAnd(expression)
+            .Then(value => new ParsedSequenceOption(ParsedSequenceOptionKind.Start, value))
+            .Or(INCREMENT.SkipAnd(BY).SkipAnd(expression)
+                .Then(value => new ParsedSequenceOption(ParsedSequenceOptionKind.Increment, value)))
+            .Or(MINVALUE.SkipAnd(expression)
+                .Then(value => new ParsedSequenceOption(ParsedSequenceOptionKind.Minimum, value)))
+            .Or(MAXVALUE.SkipAnd(expression)
+                .Then(value => new ParsedSequenceOption(ParsedSequenceOptionKind.Maximum, value)))
+            .Or(CACHE.SkipAnd(expression)
+                .Then(value => new ParsedSequenceOption(ParsedSequenceOptionKind.Cache, value)))
+            .Or(CYCLE.Then(new ParsedSequenceOption(ParsedSequenceOptionKind.Cycle)))
+            .Or(NO.SkipAnd(CYCLE).Then(new ParsedSequenceOption(ParsedSequenceOptionKind.NoCycle)));
+        var sequenceOptions = ZeroOrMany(sequenceOption).Then(CreateSequenceOptions);
+        var createSequence = CREATE.SkipAnd(SEQUENCE)
+            .SkipAnd(ifNotExists)
+            .And(tableName)
+            .And(sequenceOptions)
+            .Then<SqlStatement>(value => new CreateSequenceStatement(
+                value.Item2,
+                value.Item3,
+                value.Item1.HasValue));
+        var alterSequence = ALTER.SkipAnd(SEQUENCE)
+            .SkipAnd(tableName)
+            .And(sequenceOptions)
+            .Then<SqlStatement>(value => new AlterSequenceStatement(value.Item1, value.Item2));
+
+        var schemaObjectKind = TABLE.Then(SchemaObjectKind.Table)
+            .Or(VIEW.Then(SchemaObjectKind.View))
+            .Or(INDEX.Then(SchemaObjectKind.Index))
+            .Or(SEQUENCE.Then(SchemaObjectKind.Sequence));
+        var dropStatement = DROP.SkipAnd(schemaObjectKind)
+            .And(IF.SkipAnd(EXISTS).Optional())
+            .And(Separated(comma, tableName))
+            .And(CASCADE.Optional())
+            .Then<SqlStatement>(value => new DropStatement(
+                value.Item1,
+                value.Item3,
+                value.Item2.HasValue,
+                value.Item4.HasValue));
+        var truncateStatement = TRUNCATE.SkipAnd(TABLE.Optional())
+            .SkipAnd(Separated(comma, tableName))
+            .And(CASCADE.Optional())
+            .Then<SqlStatement>(value => new TruncateStatement(
+                value.Item1,
+                Cascade: value.Item2.HasValue));
+
+        var addColumn = ADD.SkipAnd(COLUMN.Optional()).SkipAnd(columnDefinition)
+            .Then<AlterTableAction>(value => new AddColumnAction(value));
+        var addConstraint = ADD.SkipAnd(tableConstraint)
+            .Then<AlterTableAction>(value => new AddConstraintAction(value));
+        var dropColumn = DROP.SkipAnd(COLUMN)
+            .SkipAnd(IF.SkipAnd(EXISTS).Optional())
+            .And(simpleIdentifier)
+            .And(CASCADE.Optional())
+            .Then<AlterTableAction>(value => new DropColumnAction(
+                value.Item2,
+                value.Item1.HasValue,
+                value.Item3.HasValue));
+        var dropConstraint = DROP.SkipAnd(CONSTRAINT)
+            .SkipAnd(IF.SkipAnd(EXISTS).Optional())
+            .And(simpleIdentifier)
+            .And(CASCADE.Optional())
+            .Then<AlterTableAction>(value => new DropConstraintAction(
+                value.Item2,
+                value.Item1.HasValue,
+                value.Item3.HasValue));
+        var renameColumn = RENAME.SkipAnd(COLUMN)
+            .SkipAnd(simpleIdentifier)
+            .AndSkip(TO)
+            .And(simpleIdentifier)
+            .Then<AlterTableAction>(value => new RenameColumnAction(value.Item1, value.Item2));
+        var renameTable = RENAME.SkipAnd(TO)
+            .SkipAnd(simpleIdentifier)
+            .Then<AlterTableAction>(value => new RenameTableAction(value));
+        var alterColumnType = simpleIdentifier
+            .AndSkip(TYPE)
+            .And(dataType)
+            .Then<AlterTableAction>(value => new AlterColumnAction(value.Item1, value.Item2));
+        var alterColumnDefault = simpleIdentifier
+            .AndSkip(SET)
+            .AndSkip(DEFAULT)
+            .And(expression)
+            .Then<AlterTableAction>(value => new AlterColumnAction(value.Item1, Default: value.Item2));
+        var alterColumnDropDefault = simpleIdentifier
+            .AndSkip(DROP)
+            .AndSkip(DEFAULT)
+            .Then<AlterTableAction>(value => new AlterColumnAction(value, DropDefault: true));
+        var alterColumnSetNotNull = simpleIdentifier
+            .AndSkip(SET)
+            .AndSkip(NOT)
+            .AndSkip(NULL)
+            .Then<AlterTableAction>(value => new AlterColumnAction(
+                value,
+                Nullability: Nullability.NotNull));
+        var alterColumnDropNotNull = simpleIdentifier
+            .AndSkip(DROP)
+            .AndSkip(NOT)
+            .AndSkip(NULL)
+            .Then<AlterTableAction>(value => new AlterColumnAction(
+                value,
+                Nullability: Nullability.Null));
+        var alterColumn = ALTER.SkipAnd(COLUMN)
+            .SkipAnd(alterColumnType
+                .Or(alterColumnDefault)
+                .Or(alterColumnDropDefault)
+                .Or(alterColumnSetNotNull)
+                .Or(alterColumnDropNotNull));
+        var alterTableAction = addConstraint
+            .Or(addColumn)
+            .Or(dropConstraint)
+            .Or(dropColumn)
+            .Or(alterColumn)
+            .Or(renameColumn)
+            .Or(renameTable);
+        var alterTable = ALTER.SkipAnd(TABLE)
+            .SkipAnd(tableName)
+            .And(Separated(comma, alterTableAction))
+            .Then<SqlStatement>(value => new AlterTableStatement(value.Item1, value.Item2));
 
         var statement = query.Then<SqlStatement>(value => value)
             .Or(insert)
             .Or(update)
-            .Or(delete);
+            .Or(delete)
+            .Or(merge)
+            .Or(createTable)
+            .Or(createView)
+            .Or(createIndex)
+            .Or(createSequence)
+            .Or(alterSequence)
+            .Or(alterTable)
+            .Or(dropStatement)
+            .Or(truncateStatement);
         var document = Separated(semicolon, statement)
             .AndSkip(semicolon.Optional())
             .Then(statements => new SqlDocument(statements))
@@ -630,7 +1256,7 @@ public static class SqlParser
         if (!parser.TryParse(sql, out var parsed, out var parseError))
         {
             document = null;
-            var message = parseError?.Message ?? "Invalid SQL.";
+            var message = GetParseErrorMessage(parseError);
             var errorCode = SqlParseErrorCode.Syntax;
             if (selectedDialect.ParserOptions != SqlDialectParserOptions.Permissive
                 && PermissiveParser.TryParse(sql, out _, out _))
@@ -690,6 +1316,14 @@ public static class SqlParser
             "OR", "NOT", "BETWEEN", "IN", "IS", "LIKE", "TRUE", "FALSE", "NULL",
             "EXISTS", "CASE", "WHEN", "THEN", "ELSE", "END", "CAST", "INSERT", "INTO",
             "VALUES", "UPDATE", "SET", "DELETE",
+            "DEFAULT", "COLLATE", "EXTRACT", "INTERVAL", "TRY_CAST", "FILTER", "WITHIN",
+            "WINDOW", "QUALIFY", "RANGE", "GROUPS", "UNBOUNDED", "PRECEDING", "CURRENT", "FOLLOWING",
+            "UNKNOWN", "USING", "NATURAL", "MERGE", "MATCHED",
+            "CREATE", "ALTER", "DROP", "TRUNCATE", "TABLE", "TEMPORARY", "IF", "REPLACE",
+            "VIEW", "INDEX", "UNIQUE", "SEQUENCE", "COLUMN", "CONSTRAINT", "PRIMARY", "KEY",
+            "FOREIGN", "REFERENCES", "CHECK", "CASCADE", "RESTRICT", "NO", "ACTION", "RENAME",
+            "TO", "TYPE", "GENERATED", "ALWAYS", "IDENTITY", "VIRTUAL", "STORED", "ADD",
+            "CYCLE", "CACHE", "MINVALUE", "MAXVALUE", "INCREMENT",
         };
 
         if (syntax.SupportsTop)
@@ -713,7 +1347,14 @@ public static class SqlParser
         }
 
         if (syntax.SupportsReturning) words.Add("RETURNING");
+        if (syntax.SupportsReturningInto) words.Add("INTO");
         if (syntax.SupportsILike) words.Add("ILIKE");
+        if (syntax.SupportsMinus) words.Add("MINUS");
+        if (syntax.SupportsRecursiveCte) words.UnionWith(["RECURSIVE", "MATERIALIZED"]);
+        if (syntax.SupportsHierarchicalQueries)
+        {
+            words.UnionWith(["CONNECT", "START", "NOCYCLE", "PRIOR", "CONNECT_BY_ROOT", "SIBLINGS"]);
+        }
 
         if (syntax.SupportsNullOrdering)
         {
@@ -756,13 +1397,23 @@ public static class SqlParser
     private static SqlParseError ToParseError(
         string message,
         ParseError? error,
-        SqlParseErrorCode code) =>
-        new(
+        SqlParseErrorCode code)
+    {
+        if (error is null)
+        {
+            return new SqlParseError(message, 0, 1, 1, code);
+        }
+
+        return new SqlParseError(
             message,
-            error?.Position.Offset ?? 0,
-            error?.Position.Line ?? 1,
-            error?.Position.Column ?? 1,
+            error.Position.Offset,
+            error.Position.Line,
+            error.Position.Column,
             code);
+    }
+
+    private static string GetParseErrorMessage(ParseError? error) =>
+        error?.Message ?? "Invalid SQL.";
 
     private static Parser<SqlIdentifier> QuotedIdentifier(char openQuote, char closeQuote)
     {
@@ -875,55 +1526,233 @@ public static class SqlParser
 
     private static SqlQuery ApplyQueryTail(
         SqlQuery query,
-        IReadOnlyList<OrderByItem>? orderBy,
+        ParsedOrderBy? orderBy,
         RowLimit? rowLimit) =>
         query switch
         {
             SelectStatement select => select with
             {
-                OrderBy = orderBy,
+                OrderBy = orderBy?.Items,
+                OrderSiblings = orderBy?.Siblings ?? false,
+                Limit = rowLimit?.Limit,
+                Offset = rowLimit?.Offset,
+            },
+            ValuesStatement values => values with
+            {
+                OrderBy = orderBy?.Items,
                 Limit = rowLimit?.Limit,
                 Offset = rowLimit?.Offset,
             },
             SetOperationStatement set => set with
             {
-                OrderBy = orderBy,
+                OrderBy = orderBy?.Items,
                 Limit = rowLimit?.Limit,
                 Offset = rowLimit?.Offset,
             },
             _ => query,
         };
+
+    private static SequenceOptions CreateSequenceOptions(
+        IReadOnlyList<ParsedSequenceOption> parsed)
+    {
+        SqlExpression? start = null;
+        SqlExpression? increment = null;
+        SqlExpression? minimum = null;
+        SqlExpression? maximum = null;
+        SqlExpression? cache = null;
+        bool? cycle = null;
+
+        foreach (var option in parsed)
+        {
+            if (option.Kind == ParsedSequenceOptionKind.Start)
+            {
+                start = option.Value;
+            }
+            else if (option.Kind == ParsedSequenceOptionKind.Increment)
+            {
+                increment = option.Value;
+            }
+            else if (option.Kind == ParsedSequenceOptionKind.Minimum)
+            {
+                minimum = option.Value;
+            }
+            else if (option.Kind == ParsedSequenceOptionKind.Maximum)
+            {
+                maximum = option.Value;
+            }
+            else if (option.Kind == ParsedSequenceOptionKind.Cache)
+            {
+                cache = option.Value;
+            }
+            else if (option.Kind == ParsedSequenceOptionKind.Cycle)
+            {
+                cycle = true;
+            }
+            else
+            {
+                cycle = false;
+            }
+        }
+
+        return new SequenceOptions(start, increment, minimum, maximum, cache, cycle);
+    }
+
+    private static SqlQuery BuildSetOperation(
+        SqlQuery first,
+        IReadOnlyList<SetTail> tails)
+    {
+        var queries = new Stack<SqlQuery>();
+        var operators = new Stack<(SetOperator Operator, bool IsAll)>();
+        queries.Push(first);
+
+        foreach (var tail in tails)
+        {
+            while (operators.TryPeek(out var current)
+                && GetSetOperatorPrecedence(current.Operator) >= GetSetOperatorPrecedence(tail.Operator))
+            {
+                ReduceSetOperation(queries, operators.Pop());
+            }
+
+            operators.Push((tail.Operator, tail.IsAll));
+            queries.Push(tail.Right);
+        }
+
+        while (operators.Count > 0)
+        {
+            ReduceSetOperation(queries, operators.Pop());
+        }
+
+        return queries.Pop();
+    }
+
+    private static void ReduceSetOperation(
+        Stack<SqlQuery> queries,
+        (SetOperator Operator, bool IsAll) operation)
+    {
+        var right = queries.Pop();
+        var left = queries.Pop();
+        queries.Push(new SetOperationStatement(left, operation.Operator, right, operation.IsAll));
+    }
+
+    private static int GetSetOperatorPrecedence(SetOperator value) =>
+        value == SetOperator.Intersect ? 2 : 1;
 
     private static SqlQuery ApplyCommonTableExpressions(
         SqlQuery query,
-        IReadOnlyList<CommonTableExpression> commonTableExpressions) =>
+        IReadOnlyList<CommonTableExpression> commonTableExpressions,
+        bool isRecursive) =>
         query switch
         {
-            SelectStatement select => select with { CommonTableExpressions = commonTableExpressions },
+            SelectStatement select => select with
+            {
+                CommonTableExpressions = commonTableExpressions,
+                IsRecursive = isRecursive,
+            },
             SetOperationStatement set => set with
             {
-                Left = ApplyCommonTableExpressions(set.Left, commonTableExpressions),
+                CommonTableExpressions = commonTableExpressions,
+                IsRecursive = isRecursive,
+            },
+            ValuesStatement values => values with
+            {
+                CommonTableExpressions = commonTableExpressions,
+                IsRecursive = isRecursive,
             },
             _ => query,
         };
 
+    [ExcludeFromCodeCoverage]
     private sealed record InTarget(IReadOnlyList<SqlExpression> Values, SqlQuery? Query);
 
+    [ExcludeFromCodeCoverage]
     private sealed record ParsedJoin(
         JoinKind Kind,
         TableSource Right,
         SqlExpression? Condition,
-        JoinSyntax Syntax);
+        JoinSyntax Syntax,
+        IReadOnlyList<SqlIdentifier>? Using,
+        bool IsNatural);
 
+    [ExcludeFromCodeCoverage]
+    private sealed record ParsedJoinCondition(
+        SqlExpression? Condition,
+        IReadOnlyList<SqlIdentifier>? Using);
+
+    [ExcludeFromCodeCoverage]
     private sealed record ParsedFunctionArguments(IReadOnlyList<SqlExpression> Arguments, bool IsDistinct);
 
+    [ExcludeFromCodeCoverage]
     private sealed record ParsedWindow(
         IReadOnlyList<SqlExpression>? PartitionBy,
-        IReadOnlyList<OrderByItem>? OrderBy);
+        IReadOnlyList<OrderByItem>? OrderBy,
+        WindowFrame? Frame,
+        SqlIdentifier? WindowName);
 
+    [ExcludeFromCodeCoverage]
+    private sealed record ParsedSelectHead(
+        bool IsDistinct,
+        ParsedTop? Top,
+        IReadOnlyList<SelectItem> Items,
+        TableSource? From,
+        SqlExpression? Where,
+        IReadOnlyList<SqlExpression>? GroupBy,
+        SqlExpression? Having);
+
+    [ExcludeFromCodeCoverage]
     private sealed record ParsedTop(SqlExpression Expression, bool IsPercent, bool WithTies);
 
-    private sealed record SetTail(SetOperator Operator, SelectStatement Right, bool IsAll);
+    [ExcludeFromCodeCoverage]
+    private sealed record SetTail(SetOperator Operator, SqlQuery Right, bool IsAll);
 
+    [ExcludeFromCodeCoverage]
     private sealed record RowLimit(SqlExpression? Limit, SqlExpression? Offset);
+
+    [ExcludeFromCodeCoverage]
+    private sealed record ParsedOrderBy(
+        IReadOnlyList<OrderByItem> Items,
+        bool Siblings);
+
+    [ExcludeFromCodeCoverage]
+    private sealed record ParsedWith(
+        IReadOnlyList<CommonTableExpression> Expressions,
+        bool IsRecursive);
+
+    [ExcludeFromCodeCoverage]
+    private sealed record ParsedReturning(
+        IReadOnlyList<SqlExpression> Expressions,
+        IReadOnlyList<SqlExpression>? Into);
+
+    private enum ParsedColumnModifierKind
+    {
+        Null,
+        NotNull,
+        Default,
+        Generated,
+        Identity,
+        PrimaryKey,
+        Unique,
+    }
+
+    [ExcludeFromCodeCoverage]
+    private sealed record ParsedColumnModifier(
+        ParsedColumnModifierKind Kind,
+        SqlExpression? Expression = null,
+        GeneratedColumnKind GeneratedKind = GeneratedColumnKind.Virtual,
+        IdentityGeneration Identity = IdentityGeneration.None);
+
+    private enum ParsedSequenceOptionKind
+    {
+        Start,
+        Increment,
+        Minimum,
+        Maximum,
+        Cache,
+        Cycle,
+        NoCycle,
+    }
+
+    [ExcludeFromCodeCoverage]
+    private sealed record ParsedSequenceOption(
+        ParsedSequenceOptionKind Kind,
+        SqlExpression? Value = null);
 }

--- a/src/Cyqwel/Visitors/SqlNodeChildren.Standard.cs
+++ b/src/Cyqwel/Visitors/SqlNodeChildren.Standard.cs
@@ -1,0 +1,127 @@
+using Cyqwel.Ast;
+
+namespace Cyqwel.Visitors;
+
+internal static partial class SqlNodeChildren
+{
+    private static IEnumerable<SqlNode> ValuesChildren(ValuesStatement node)
+    {
+        if (node.CommonTableExpressions is not null)
+        {
+            foreach (var cte in node.CommonTableExpressions) yield return cte;
+        }
+
+        foreach (var row in node.Rows)
+        {
+            foreach (var value in row) yield return value;
+        }
+
+        if (node.OrderBy is not null)
+        {
+            foreach (var item in node.OrderBy) yield return item;
+        }
+
+        if (node.Limit is not null) yield return node.Limit;
+        if (node.Offset is not null) yield return node.Offset;
+    }
+
+    private static IEnumerable<SqlNode> MergeChildren(MergeStatement node)
+    {
+        yield return node.Target;
+        yield return node.Source;
+        yield return node.Condition;
+        foreach (var when in node.WhenClauses) yield return when;
+        if (node.Returning is not null)
+        {
+            foreach (var value in node.Returning) yield return value;
+        }
+
+        if (node.ReturningInto is not null)
+        {
+            foreach (var value in node.ReturningInto) yield return value;
+        }
+    }
+
+    private static IEnumerable<SqlNode> CreateTableChildren(CreateTableStatement node)
+    {
+        yield return node.Name;
+        foreach (var element in node.Elements) yield return element;
+        if (node.AsQuery is not null) yield return node.AsQuery;
+    }
+
+    private static IEnumerable<SqlNode> CreateViewChildren(CreateViewStatement node)
+    {
+        yield return node.Name;
+        if (node.Columns is not null)
+        {
+            foreach (var column in node.Columns) yield return column;
+        }
+
+        yield return node.Query;
+    }
+
+    private static IEnumerable<SqlNode> CreateIndexChildren(CreateIndexStatement node)
+    {
+        yield return node.Name;
+        yield return node.Table;
+        foreach (var column in node.Columns) yield return column;
+        if (node.Where is not null) yield return node.Where;
+    }
+
+    private static IEnumerable<SqlNode> WindowDefinitionChildren(WindowDefinition node)
+    {
+        yield return node.Name;
+        if (node.BaseWindow is not null) yield return node.BaseWindow;
+        if (node.PartitionBy is not null)
+        {
+            foreach (var value in node.PartitionBy) yield return value;
+        }
+
+        if (node.OrderBy is not null)
+        {
+            foreach (var value in node.OrderBy) yield return value;
+        }
+
+        if (node.Frame is not null) yield return node.Frame;
+    }
+
+    private static IEnumerable<SqlNode> ColumnDefinitionChildren(ColumnDefinition node)
+    {
+        yield return node.Name;
+        yield return node.DataType;
+        if (node.Default is not null) yield return node.Default;
+        if (node.GeneratedExpression is not null) yield return node.GeneratedExpression;
+    }
+
+    private static IEnumerable<SqlNode> ConstraintChildren(
+        SqlIdentifier? name,
+        IReadOnlyList<SqlIdentifier> columns)
+    {
+        if (name is not null) yield return name;
+        foreach (var column in columns) yield return column;
+    }
+
+    private static IEnumerable<SqlNode> ForeignKeyChildren(ForeignKeyConstraint node)
+    {
+        if (node.Name is not null) yield return node.Name;
+        foreach (var column in node.Columns) yield return column;
+        yield return node.ReferencedTable;
+        foreach (var column in node.ReferencedColumns) yield return column;
+    }
+
+    private static IEnumerable<SqlNode> AlterColumnChildren(AlterColumnAction node)
+    {
+        yield return node.Column;
+        if (node.DataType is not null) yield return node.DataType;
+        if (node.Default is not null) yield return node.Default;
+    }
+
+    private static IEnumerable<SqlNode> SequenceOptionChildren(SequenceOptions node)
+    {
+        if (node.StartWith is not null) yield return node.StartWith;
+        if (node.IncrementBy is not null) yield return node.IncrementBy;
+        if (node.MinimumValue is not null) yield return node.MinimumValue;
+        if (node.MaximumValue is not null) yield return node.MaximumValue;
+        if (node.Cache is not null) yield return node.Cache;
+    }
+}

--- a/src/Cyqwel/Visitors/SqlNodeChildren.cs
+++ b/src/Cyqwel/Visitors/SqlNodeChildren.cs
@@ -2,7 +2,7 @@ using Cyqwel.Ast;
 
 namespace Cyqwel.Visitors;
 
-internal static class SqlNodeChildren
+internal static partial class SqlNodeChildren
 {
     public static IEnumerable<SqlNode> Get(SqlNode node)
     {
@@ -12,6 +12,8 @@ internal static class SqlNodeChildren
                 return value.Statements;
             case SelectStatement value:
                 return SelectChildren(value);
+            case ValuesStatement value:
+                return ValuesChildren(value);
             case SetOperationStatement value:
                 return SetOperationChildren(value);
             case InsertStatement value:
@@ -20,6 +22,24 @@ internal static class SqlNodeChildren
                 return UpdateChildren(value);
             case DeleteStatement value:
                 return DeleteChildren(value);
+            case MergeStatement value:
+                return MergeChildren(value);
+            case CreateTableStatement value:
+                return CreateTableChildren(value);
+            case AlterTableStatement value:
+                return [value.Name, .. value.Actions];
+            case DropStatement value:
+                return value.Names;
+            case TruncateStatement value:
+                return value.Tables;
+            case CreateViewStatement value:
+                return CreateViewChildren(value);
+            case CreateIndexStatement value:
+                return CreateIndexChildren(value);
+            case CreateSequenceStatement value:
+                return [value.Name, value.Options];
+            case AlterSequenceStatement value:
+                return [value.Name, value.Options];
             case ColumnExpression value:
                 return value.Parts;
             case StarExpression value:
@@ -36,6 +56,20 @@ internal static class SqlNodeChildren
                 return InChildren(value);
             case IsNullExpression value:
                 return [value.Expression];
+            case BooleanTestExpression value:
+                return [value.Expression];
+            case DistinctFromExpression value:
+                return [value.Left, value.Right];
+            case RowExpression value:
+                return value.Values;
+            case CollateExpression value:
+                return [value.Expression, value.Collation];
+            case ExtractExpression value:
+                return [value.Field, value.Expression];
+            case IntervalExpression value:
+                return [value.Value, value.Unit];
+            case SequenceValueExpression value:
+                return [value.Sequence];
             case FunctionCallExpression value:
                 return FunctionChildren(value);
             case WindowExpression value:
@@ -50,6 +84,8 @@ internal static class SqlNodeChildren
                 return CaseChildren(value);
             case CastExpression value:
                 return [value.Expression, value.DataType];
+            case TryCastExpression value:
+                return [value.Expression, value.DataType];
             case SqlDataType value:
                 return [value.Name];
             case TableName value:
@@ -59,9 +95,7 @@ internal static class SqlNodeChildren
             case DerivedTable value:
                 return [value.Query, value.Alias];
             case JoinTable value:
-                return value.Condition is null
-                    ? [value.Left, value.Right]
-                    : [value.Left, value.Right, value.Condition];
+                return JoinChildren(value);
             case SelectItem value:
                 return value.Alias is null ? [value.Expression] : [value.Expression, value.Alias];
             case OrderByItem value:
@@ -70,8 +104,58 @@ internal static class SqlNodeChildren
                 return CommonTableExpressionChildren(value);
             case Assignment value:
                 return [value.Column, value.Value];
+            case WindowDefinition value:
+                return WindowDefinitionChildren(value);
+            case WindowFrame value:
+                return value.End is null ? [value.Start] : [value.Start, value.End];
+            case WindowFrameBound value:
+                return value.Offset is null ? Array.Empty<SqlNode>() : [value.Offset];
+            case ConnectByClause value:
+                return value.StartWith is null
+                    ? [value.Condition]
+                    : [value.StartWith, value.Condition];
+            case MergeWhenClause value:
+                return value.Condition is null ? [value.Action] : [value.Condition, value.Action];
+            case MergeUpdateAction value:
+                return value.DeleteWhere is null
+                    ? value.Assignments
+                    : [.. value.Assignments, value.DeleteWhere];
+            case MergeInsertAction value:
+                return value.Columns is null
+                    ? value.Values
+                    : [.. value.Columns, .. value.Values];
+            case ColumnDefinition value:
+                return ColumnDefinitionChildren(value);
+            case PrimaryKeyConstraint value:
+                return ConstraintChildren(value.Name, value.Columns);
+            case UniqueConstraint value:
+                return ConstraintChildren(value.Name, value.Columns);
+            case ForeignKeyConstraint value:
+                return ForeignKeyChildren(value);
+            case CheckConstraint value:
+                return value.Name is null ? [value.Condition] : [value.Name, value.Condition];
+            case AddColumnAction value:
+                return [value.Column];
+            case DropColumnAction value:
+                return [value.Column];
+            case AlterColumnAction value:
+                return AlterColumnChildren(value);
+            case AddConstraintAction value:
+                return [value.Constraint];
+            case DropConstraintAction value:
+                return [value.Constraint];
+            case RenameColumnAction value:
+                return [value.Column, value.NewName];
+            case RenameTableAction value:
+                return [value.NewName];
+            case IndexColumn value:
+                return [value.Expression];
+            case SequenceOptions value:
+                return SequenceOptionChildren(value);
             case SqlIdentifier:
             case LiteralExpression:
+            case DefaultExpression:
+            case MergeDeleteAction:
                 return Array.Empty<SqlNode>();
             case ParameterExpression value:
                 return value.DefaultValue is null
@@ -101,6 +185,14 @@ internal static class SqlNodeChildren
 
         if (node.Having is not null) yield return node.Having;
 
+        if (node.Windows is not null)
+        {
+            foreach (var window in node.Windows) yield return window;
+        }
+
+        if (node.Qualify is not null) yield return node.Qualify;
+        if (node.ConnectBy is not null) yield return node.ConnectBy;
+
         if (node.OrderBy is not null)
         {
             foreach (var item in node.OrderBy) yield return item;
@@ -114,6 +206,11 @@ internal static class SqlNodeChildren
     {
         yield return node.Left;
         yield return node.Right;
+
+        if (node.CommonTableExpressions is not null)
+        {
+            foreach (var cte in node.CommonTableExpressions) yield return cte;
+        }
 
         if (node.OrderBy is not null)
         {
@@ -147,28 +244,45 @@ internal static class SqlNodeChildren
         {
             foreach (var expression in node.Returning) yield return expression;
         }
+
+        if (node.ReturningInto is not null)
+        {
+            foreach (var expression in node.ReturningInto) yield return expression;
+        }
     }
 
     private static IEnumerable<SqlNode> UpdateChildren(UpdateStatement node)
     {
         yield return node.Target;
         foreach (var assignment in node.Assignments) yield return assignment;
+        if (node.From is not null) yield return node.From;
         if (node.Where is not null) yield return node.Where;
 
         if (node.Returning is not null)
         {
             foreach (var expression in node.Returning) yield return expression;
         }
+
+        if (node.ReturningInto is not null)
+        {
+            foreach (var expression in node.ReturningInto) yield return expression;
+        }
     }
 
     private static IEnumerable<SqlNode> DeleteChildren(DeleteStatement node)
     {
         yield return node.Target;
+        if (node.Using is not null) yield return node.Using;
         if (node.Where is not null) yield return node.Where;
 
         if (node.Returning is not null)
         {
             foreach (var expression in node.Returning) yield return expression;
+        }
+
+        if (node.ReturningInto is not null)
+        {
+            foreach (var expression in node.ReturningInto) yield return expression;
         }
     }
 
@@ -183,6 +297,11 @@ internal static class SqlNodeChildren
     {
         yield return node.Name;
         foreach (var argument in node.Arguments) yield return argument;
+        if (node.Filter is not null) yield return node.Filter;
+        if (node.WithinGroup is not null)
+        {
+            foreach (var item in node.WithinGroup) yield return item;
+        }
     }
 
     private static IEnumerable<SqlNode> WindowChildren(WindowExpression node)
@@ -197,6 +316,9 @@ internal static class SqlNodeChildren
         {
             foreach (var item in node.OrderBy) yield return item;
         }
+
+        if (node.Frame is not null) yield return node.Frame;
+        if (node.WindowName is not null) yield return node.WindowName;
     }
 
     private static IEnumerable<SqlNode> CaseChildren(CaseExpression node)
@@ -216,5 +338,16 @@ internal static class SqlNodeChildren
         }
 
         yield return node.Query;
+    }
+
+    private static IEnumerable<SqlNode> JoinChildren(JoinTable node)
+    {
+        yield return node.Left;
+        yield return node.Right;
+        if (node.Condition is not null) yield return node.Condition;
+        if (node.Using is not null)
+        {
+            foreach (var column in node.Using) yield return column;
+        }
     }
 }

--- a/src/Cyqwel/Visitors/SqlRewriter.Standard.cs
+++ b/src/Cyqwel/Visitors/SqlRewriter.Standard.cs
@@ -1,0 +1,387 @@
+using Cyqwel.Ast;
+
+namespace Cyqwel.Visitors;
+
+public abstract partial class SqlRewriter
+{
+    protected virtual SqlNode VisitValues(ValuesStatement node)
+    {
+        var rows = VisitRows(node.Rows)!;
+        var orderBy = VisitOptionalList(node.OrderBy);
+        var limit = VisitOptional(node.Limit);
+        var offset = VisitOptional(node.Offset);
+        var ctes = VisitOptionalList(node.CommonTableExpressions);
+        return ReferenceEquals(rows, node.Rows)
+            && ReferenceEquals(orderBy, node.OrderBy)
+            && ReferenceEquals(limit, node.Limit)
+            && ReferenceEquals(offset, node.Offset)
+            && ReferenceEquals(ctes, node.CommonTableExpressions)
+                ? node
+                : node with
+                {
+                    Rows = rows,
+                    OrderBy = orderBy,
+                    Limit = limit,
+                    Offset = offset,
+                    CommonTableExpressions = ctes,
+                };
+    }
+
+    protected virtual SqlNode VisitMerge(MergeStatement node)
+    {
+        var target = Visit(node.Target);
+        var source = Visit(node.Source);
+        var condition = Visit(node.Condition);
+        var whenClauses = VisitList(node.WhenClauses);
+        var returning = VisitOptionalList(node.Returning);
+        var returningInto = VisitOptionalList(node.ReturningInto);
+        return ReferenceEquals(target, node.Target)
+            && ReferenceEquals(source, node.Source)
+            && ReferenceEquals(condition, node.Condition)
+            && ReferenceEquals(whenClauses, node.WhenClauses)
+            && ReferenceEquals(returning, node.Returning)
+            && ReferenceEquals(returningInto, node.ReturningInto)
+                ? node
+                : node with
+                {
+                    Target = target,
+                    Source = source,
+                    Condition = condition,
+                    WhenClauses = whenClauses,
+                    Returning = returning,
+                    ReturningInto = returningInto,
+                };
+    }
+
+    protected virtual SqlNode VisitCreateTable(CreateTableStatement node)
+    {
+        var name = Visit(node.Name);
+        var elements = VisitList(node.Elements);
+        var asQuery = VisitOptional(node.AsQuery);
+        return ReferenceEquals(name, node.Name)
+            && ReferenceEquals(elements, node.Elements)
+            && ReferenceEquals(asQuery, node.AsQuery)
+                ? node
+                : node with { Name = name, Elements = elements, AsQuery = asQuery };
+    }
+
+    protected virtual SqlNode VisitAlterTable(AlterTableStatement node)
+    {
+        var name = Visit(node.Name);
+        var actions = VisitList(node.Actions);
+        return ReferenceEquals(name, node.Name) && ReferenceEquals(actions, node.Actions)
+            ? node
+            : node with { Name = name, Actions = actions };
+    }
+
+    protected virtual SqlNode VisitDrop(DropStatement node) =>
+        Update(node, VisitList(node.Names), node.Names, static (n, names) => n with { Names = names });
+
+    protected virtual SqlNode VisitTruncate(TruncateStatement node) =>
+        Update(node, VisitList(node.Tables), node.Tables, static (n, tables) => n with { Tables = tables });
+
+    protected virtual SqlNode VisitCreateView(CreateViewStatement node)
+    {
+        var name = Visit(node.Name);
+        var query = Visit(node.Query);
+        var columns = VisitOptionalList(node.Columns);
+        return ReferenceEquals(name, node.Name)
+            && ReferenceEquals(query, node.Query)
+            && ReferenceEquals(columns, node.Columns)
+                ? node
+                : node with { Name = name, Query = query, Columns = columns };
+    }
+
+    protected virtual SqlNode VisitCreateIndex(CreateIndexStatement node)
+    {
+        var name = Visit(node.Name);
+        var table = Visit(node.Table);
+        var columns = VisitList(node.Columns);
+        var where = VisitOptional(node.Where);
+        return ReferenceEquals(name, node.Name)
+            && ReferenceEquals(table, node.Table)
+            && ReferenceEquals(columns, node.Columns)
+            && ReferenceEquals(where, node.Where)
+                ? node
+                : node with { Name = name, Table = table, Columns = columns, Where = where };
+    }
+
+    protected virtual SqlNode VisitCreateSequence(CreateSequenceStatement node)
+    {
+        var name = Visit(node.Name);
+        var options = Visit(node.Options);
+        return ReferenceEquals(name, node.Name) && ReferenceEquals(options, node.Options)
+            ? node
+            : node with { Name = name, Options = options };
+    }
+
+    protected virtual SqlNode VisitAlterSequence(AlterSequenceStatement node)
+    {
+        var name = Visit(node.Name);
+        var options = Visit(node.Options);
+        return ReferenceEquals(name, node.Name) && ReferenceEquals(options, node.Options)
+            ? node
+            : node with { Name = name, Options = options };
+    }
+
+    protected virtual SqlNode VisitBooleanTest(BooleanTestExpression node) =>
+        Update(node, Visit(node.Expression), node.Expression, static (n, value) => n with { Expression = value });
+
+    protected virtual SqlNode VisitDistinctFrom(DistinctFromExpression node)
+    {
+        var left = Visit(node.Left);
+        var right = Visit(node.Right);
+        return ReferenceEquals(left, node.Left) && ReferenceEquals(right, node.Right)
+            ? node
+            : node with { Left = left, Right = right };
+    }
+
+    protected virtual SqlNode VisitRow(RowExpression node) =>
+        Update(node, VisitList(node.Values), node.Values, static (n, values) => n with { Values = values });
+
+    protected virtual SqlNode VisitDefault(DefaultExpression node) => node;
+
+    protected virtual SqlNode VisitCollate(CollateExpression node)
+    {
+        var expression = Visit(node.Expression);
+        var collation = Visit(node.Collation);
+        return ReferenceEquals(expression, node.Expression) && ReferenceEquals(collation, node.Collation)
+            ? node
+            : node with { Expression = expression, Collation = collation };
+    }
+
+    protected virtual SqlNode VisitExtract(ExtractExpression node)
+    {
+        var field = Visit(node.Field);
+        var expression = Visit(node.Expression);
+        return ReferenceEquals(field, node.Field) && ReferenceEquals(expression, node.Expression)
+            ? node
+            : node with { Field = field, Expression = expression };
+    }
+
+    protected virtual SqlNode VisitInterval(IntervalExpression node)
+    {
+        var value = Visit(node.Value);
+        var unit = Visit(node.Unit);
+        return ReferenceEquals(value, node.Value) && ReferenceEquals(unit, node.Unit)
+            ? node
+            : node with { Value = value, Unit = unit };
+    }
+
+    protected virtual SqlNode VisitSequenceValue(SequenceValueExpression node) =>
+        Update(node, Visit(node.Sequence), node.Sequence, static (n, value) => n with { Sequence = value });
+
+    protected virtual SqlNode VisitTryCast(TryCastExpression node)
+    {
+        var expression = Visit(node.Expression);
+        var dataType = Visit(node.DataType);
+        return ReferenceEquals(expression, node.Expression) && ReferenceEquals(dataType, node.DataType)
+            ? node
+            : node with { Expression = expression, DataType = dataType };
+    }
+
+    protected virtual SqlNode VisitWindowDefinition(WindowDefinition node)
+    {
+        var name = Visit(node.Name);
+        var baseWindow = VisitOptional(node.BaseWindow);
+        var partitionBy = VisitOptionalList(node.PartitionBy);
+        var orderBy = VisitOptionalList(node.OrderBy);
+        var frame = VisitOptional(node.Frame);
+        return ReferenceEquals(name, node.Name)
+            && ReferenceEquals(baseWindow, node.BaseWindow)
+            && ReferenceEquals(partitionBy, node.PartitionBy)
+            && ReferenceEquals(orderBy, node.OrderBy)
+            && ReferenceEquals(frame, node.Frame)
+                ? node
+                : node with
+                {
+                    Name = name,
+                    BaseWindow = baseWindow,
+                    PartitionBy = partitionBy,
+                    OrderBy = orderBy,
+                    Frame = frame,
+                };
+    }
+
+    protected virtual SqlNode VisitWindowFrame(WindowFrame node)
+    {
+        var start = Visit(node.Start);
+        var end = VisitOptional(node.End);
+        return ReferenceEquals(start, node.Start) && ReferenceEquals(end, node.End)
+            ? node
+            : node with { Start = start, End = end };
+    }
+
+    protected virtual SqlNode VisitWindowFrameBound(WindowFrameBound node)
+    {
+        var offset = VisitOptional(node.Offset);
+        return ReferenceEquals(offset, node.Offset) ? node : node with { Offset = offset };
+    }
+
+    protected virtual SqlNode VisitConnectBy(ConnectByClause node)
+    {
+        var condition = Visit(node.Condition);
+        var startWith = VisitOptional(node.StartWith);
+        return ReferenceEquals(condition, node.Condition) && ReferenceEquals(startWith, node.StartWith)
+            ? node
+            : node with { Condition = condition, StartWith = startWith };
+    }
+
+    protected virtual SqlNode VisitMergeWhen(MergeWhenClause node)
+    {
+        var action = Visit(node.Action);
+        var condition = VisitOptional(node.Condition);
+        return ReferenceEquals(action, node.Action) && ReferenceEquals(condition, node.Condition)
+            ? node
+            : node with { Action = action, Condition = condition };
+    }
+
+    protected virtual SqlNode VisitMergeUpdate(MergeUpdateAction node)
+    {
+        var assignments = VisitList(node.Assignments);
+        var deleteWhere = VisitOptional(node.DeleteWhere);
+        return ReferenceEquals(assignments, node.Assignments) && ReferenceEquals(deleteWhere, node.DeleteWhere)
+            ? node
+            : node with { Assignments = assignments, DeleteWhere = deleteWhere };
+    }
+
+    protected virtual SqlNode VisitMergeInsert(MergeInsertAction node)
+    {
+        var columns = VisitOptionalList(node.Columns);
+        var values = VisitList(node.Values);
+        return ReferenceEquals(columns, node.Columns) && ReferenceEquals(values, node.Values)
+            ? node
+            : node with { Columns = columns, Values = values };
+    }
+
+    protected virtual SqlNode VisitMergeDelete(MergeDeleteAction node) => node;
+
+    protected virtual SqlNode VisitColumnDefinition(ColumnDefinition node)
+    {
+        var name = Visit(node.Name);
+        var dataType = Visit(node.DataType);
+        var defaultValue = VisitOptional(node.Default);
+        var generated = VisitOptional(node.GeneratedExpression);
+        return ReferenceEquals(name, node.Name)
+            && ReferenceEquals(dataType, node.DataType)
+            && ReferenceEquals(defaultValue, node.Default)
+            && ReferenceEquals(generated, node.GeneratedExpression)
+                ? node
+                : node with
+                {
+                    Name = name,
+                    DataType = dataType,
+                    Default = defaultValue,
+                    GeneratedExpression = generated,
+                };
+    }
+
+    protected virtual SqlNode VisitPrimaryKeyConstraint(PrimaryKeyConstraint node)
+    {
+        var columns = VisitList(node.Columns);
+        var name = VisitOptional(node.Name);
+        return ReferenceEquals(columns, node.Columns) && ReferenceEquals(name, node.Name)
+            ? node
+            : node with { Columns = columns, Name = name };
+    }
+
+    protected virtual SqlNode VisitUniqueConstraint(UniqueConstraint node)
+    {
+        var columns = VisitList(node.Columns);
+        var name = VisitOptional(node.Name);
+        return ReferenceEquals(columns, node.Columns) && ReferenceEquals(name, node.Name)
+            ? node
+            : node with { Columns = columns, Name = name };
+    }
+
+    protected virtual SqlNode VisitForeignKeyConstraint(ForeignKeyConstraint node)
+    {
+        var columns = VisitList(node.Columns);
+        var table = Visit(node.ReferencedTable);
+        var referencedColumns = VisitList(node.ReferencedColumns);
+        var name = VisitOptional(node.Name);
+        return ReferenceEquals(columns, node.Columns)
+            && ReferenceEquals(table, node.ReferencedTable)
+            && ReferenceEquals(referencedColumns, node.ReferencedColumns)
+            && ReferenceEquals(name, node.Name)
+                ? node
+                : node with
+                {
+                    Columns = columns,
+                    ReferencedTable = table,
+                    ReferencedColumns = referencedColumns,
+                    Name = name,
+                };
+    }
+
+    protected virtual SqlNode VisitCheckConstraint(CheckConstraint node)
+    {
+        var condition = Visit(node.Condition);
+        var name = VisitOptional(node.Name);
+        return ReferenceEquals(condition, node.Condition) && ReferenceEquals(name, node.Name)
+            ? node
+            : node with { Condition = condition, Name = name };
+    }
+
+    protected virtual SqlNode VisitAddColumn(AddColumnAction node) =>
+        Update(node, Visit(node.Column), node.Column, static (n, value) => n with { Column = value });
+
+    protected virtual SqlNode VisitDropColumn(DropColumnAction node) =>
+        Update(node, Visit(node.Column), node.Column, static (n, value) => n with { Column = value });
+
+    protected virtual SqlNode VisitAlterColumn(AlterColumnAction node)
+    {
+        var column = Visit(node.Column);
+        var dataType = VisitOptional(node.DataType);
+        var defaultValue = VisitOptional(node.Default);
+        return ReferenceEquals(column, node.Column)
+            && ReferenceEquals(dataType, node.DataType)
+            && ReferenceEquals(defaultValue, node.Default)
+                ? node
+                : node with { Column = column, DataType = dataType, Default = defaultValue };
+    }
+
+    protected virtual SqlNode VisitAddConstraint(AddConstraintAction node) =>
+        Update(node, Visit(node.Constraint), node.Constraint, static (n, value) => n with { Constraint = value });
+
+    protected virtual SqlNode VisitDropConstraint(DropConstraintAction node) =>
+        Update(node, Visit(node.Constraint), node.Constraint, static (n, value) => n with { Constraint = value });
+
+    protected virtual SqlNode VisitRenameColumn(RenameColumnAction node)
+    {
+        var column = Visit(node.Column);
+        var newName = Visit(node.NewName);
+        return ReferenceEquals(column, node.Column) && ReferenceEquals(newName, node.NewName)
+            ? node
+            : node with { Column = column, NewName = newName };
+    }
+
+    protected virtual SqlNode VisitRenameTable(RenameTableAction node) =>
+        Update(node, Visit(node.NewName), node.NewName, static (n, value) => n with { NewName = value });
+
+    protected virtual SqlNode VisitIndexColumn(IndexColumn node) =>
+        Update(node, Visit(node.Expression), node.Expression, static (n, value) => n with { Expression = value });
+
+    protected virtual SqlNode VisitSequenceOptions(SequenceOptions node)
+    {
+        var start = VisitOptional(node.StartWith);
+        var increment = VisitOptional(node.IncrementBy);
+        var minimum = VisitOptional(node.MinimumValue);
+        var maximum = VisitOptional(node.MaximumValue);
+        var cache = VisitOptional(node.Cache);
+        return ReferenceEquals(start, node.StartWith)
+            && ReferenceEquals(increment, node.IncrementBy)
+            && ReferenceEquals(minimum, node.MinimumValue)
+            && ReferenceEquals(maximum, node.MaximumValue)
+            && ReferenceEquals(cache, node.Cache)
+                ? node
+                : node with
+                {
+                    StartWith = start,
+                    IncrementBy = increment,
+                    MinimumValue = minimum,
+                    MaximumValue = maximum,
+                    Cache = cache,
+                };
+    }
+}

--- a/src/Cyqwel/Visitors/SqlRewriter.cs
+++ b/src/Cyqwel/Visitors/SqlRewriter.cs
@@ -5,7 +5,7 @@ namespace Cyqwel.Visitors;
 /// <summary>
 /// Rewrites SQL trees bottom-up while preserving unchanged node instances.
 /// </summary>
-public abstract class SqlRewriter
+public abstract partial class SqlRewriter
 {
     public virtual SqlNode Visit(SqlNode node)
     {
@@ -15,10 +15,20 @@ public abstract class SqlRewriter
         {
             SqlDocument value => VisitDocument(value),
             SelectStatement value => VisitSelect(value),
+            ValuesStatement value => VisitValues(value),
             SetOperationStatement value => VisitSetOperation(value),
             InsertStatement value => VisitInsert(value),
             UpdateStatement value => VisitUpdate(value),
             DeleteStatement value => VisitDelete(value),
+            MergeStatement value => VisitMerge(value),
+            CreateTableStatement value => VisitCreateTable(value),
+            AlterTableStatement value => VisitAlterTable(value),
+            DropStatement value => VisitDrop(value),
+            TruncateStatement value => VisitTruncate(value),
+            CreateViewStatement value => VisitCreateView(value),
+            CreateIndexStatement value => VisitCreateIndex(value),
+            CreateSequenceStatement value => VisitCreateSequence(value),
+            AlterSequenceStatement value => VisitAlterSequence(value),
             SqlIdentifier value => VisitIdentifier(value),
             ColumnExpression value => VisitColumn(value),
             StarExpression value => VisitStar(value),
@@ -30,6 +40,14 @@ public abstract class SqlRewriter
             BetweenExpression value => VisitBetween(value),
             InExpression value => VisitIn(value),
             IsNullExpression value => VisitIsNull(value),
+            BooleanTestExpression value => VisitBooleanTest(value),
+            DistinctFromExpression value => VisitDistinctFrom(value),
+            RowExpression value => VisitRow(value),
+            DefaultExpression value => VisitDefault(value),
+            CollateExpression value => VisitCollate(value),
+            ExtractExpression value => VisitExtract(value),
+            IntervalExpression value => VisitInterval(value),
+            SequenceValueExpression value => VisitSequenceValue(value),
             FunctionCallExpression value => VisitFunctionCall(value),
             WindowExpression value => VisitWindow(value),
             ExistsExpression value => VisitExists(value),
@@ -37,6 +55,7 @@ public abstract class SqlRewriter
             WhenClause value => VisitWhen(value),
             CaseExpression value => VisitCase(value),
             CastExpression value => VisitCast(value),
+            TryCastExpression value => VisitTryCast(value),
             SqlDataType value => VisitDataType(value),
             TableName value => VisitTableName(value),
             NamedTable value => VisitNamedTable(value),
@@ -46,6 +65,28 @@ public abstract class SqlRewriter
             OrderByItem value => VisitOrderByItem(value),
             CommonTableExpression value => VisitCommonTableExpression(value),
             Assignment value => VisitAssignment(value),
+            WindowDefinition value => VisitWindowDefinition(value),
+            WindowFrame value => VisitWindowFrame(value),
+            WindowFrameBound value => VisitWindowFrameBound(value),
+            ConnectByClause value => VisitConnectBy(value),
+            MergeWhenClause value => VisitMergeWhen(value),
+            MergeUpdateAction value => VisitMergeUpdate(value),
+            MergeInsertAction value => VisitMergeInsert(value),
+            MergeDeleteAction value => VisitMergeDelete(value),
+            ColumnDefinition value => VisitColumnDefinition(value),
+            PrimaryKeyConstraint value => VisitPrimaryKeyConstraint(value),
+            UniqueConstraint value => VisitUniqueConstraint(value),
+            ForeignKeyConstraint value => VisitForeignKeyConstraint(value),
+            CheckConstraint value => VisitCheckConstraint(value),
+            AddColumnAction value => VisitAddColumn(value),
+            DropColumnAction value => VisitDropColumn(value),
+            AlterColumnAction value => VisitAlterColumn(value),
+            AddConstraintAction value => VisitAddConstraint(value),
+            DropConstraintAction value => VisitDropConstraint(value),
+            RenameColumnAction value => VisitRenameColumn(value),
+            RenameTableAction value => VisitRenameTable(value),
+            IndexColumn value => VisitIndexColumn(value),
+            SequenceOptions value => VisitSequenceOptions(value),
             _ => throw new NotSupportedException($"Unsupported SQL node type '{node.GetType().Name}'."),
         };
     }
@@ -67,6 +108,9 @@ public abstract class SqlRewriter
         var offset = VisitOptional(node.Offset);
         var ctes = VisitOptionalList(node.CommonTableExpressions);
         var top = VisitOptional(node.Top);
+        var windows = VisitOptionalList(node.Windows);
+        var qualify = VisitOptional(node.Qualify);
+        var connectBy = VisitOptional(node.ConnectBy);
 
         return ReferenceEquals(projections, node.Projections)
             && ReferenceEquals(from, node.From)
@@ -78,6 +122,9 @@ public abstract class SqlRewriter
             && ReferenceEquals(offset, node.Offset)
             && ReferenceEquals(ctes, node.CommonTableExpressions)
             && ReferenceEquals(top, node.Top)
+            && ReferenceEquals(windows, node.Windows)
+            && ReferenceEquals(qualify, node.Qualify)
+            && ReferenceEquals(connectBy, node.ConnectBy)
                 ? node
                 : node with
                 {
@@ -91,6 +138,9 @@ public abstract class SqlRewriter
                     Offset = offset,
                     CommonTableExpressions = ctes,
                     Top = top,
+                    Windows = windows,
+                    Qualify = qualify,
+                    ConnectBy = connectBy,
                 };
     }
 
@@ -101,14 +151,24 @@ public abstract class SqlRewriter
         var orderBy = VisitOptionalList(node.OrderBy);
         var limit = VisitOptional(node.Limit);
         var offset = VisitOptional(node.Offset);
+        var ctes = VisitOptionalList(node.CommonTableExpressions);
 
         return ReferenceEquals(left, node.Left)
             && ReferenceEquals(right, node.Right)
             && ReferenceEquals(orderBy, node.OrderBy)
             && ReferenceEquals(limit, node.Limit)
             && ReferenceEquals(offset, node.Offset)
+            && ReferenceEquals(ctes, node.CommonTableExpressions)
                 ? node
-                : node with { Left = left, Right = right, OrderBy = orderBy, Limit = limit, Offset = offset };
+                : node with
+                {
+                    Left = left,
+                    Right = right,
+                    OrderBy = orderBy,
+                    Limit = limit,
+                    Offset = offset,
+                    CommonTableExpressions = ctes,
+                };
     }
 
     protected virtual SqlNode VisitInsert(InsertStatement node)
@@ -118,14 +178,24 @@ public abstract class SqlRewriter
         var values = VisitRows(node.Values);
         var source = VisitOptional(node.Source);
         var returning = VisitOptionalList(node.Returning);
+        var returningInto = VisitOptionalList(node.ReturningInto);
 
         return ReferenceEquals(target, node.Target)
             && ReferenceEquals(columns, node.Columns)
             && ReferenceEquals(values, node.Values)
             && ReferenceEquals(source, node.Source)
             && ReferenceEquals(returning, node.Returning)
+            && ReferenceEquals(returningInto, node.ReturningInto)
                 ? node
-                : node with { Target = target, Columns = columns, Values = values, Source = source, Returning = returning };
+                : node with
+                {
+                    Target = target,
+                    Columns = columns,
+                    Values = values,
+                    Source = source,
+                    Returning = returning,
+                    ReturningInto = returningInto,
+                };
     }
 
     protected virtual SqlNode VisitUpdate(UpdateStatement node)
@@ -134,13 +204,25 @@ public abstract class SqlRewriter
         var assignments = VisitList(node.Assignments);
         var where = VisitOptional(node.Where);
         var returning = VisitOptionalList(node.Returning);
+        var returningInto = VisitOptionalList(node.ReturningInto);
+        var from = VisitOptional(node.From);
 
         return ReferenceEquals(target, node.Target)
             && ReferenceEquals(assignments, node.Assignments)
             && ReferenceEquals(where, node.Where)
             && ReferenceEquals(returning, node.Returning)
+            && ReferenceEquals(returningInto, node.ReturningInto)
+            && ReferenceEquals(from, node.From)
                 ? node
-                : node with { Target = target, Assignments = assignments, Where = where, Returning = returning };
+                : node with
+                {
+                    Target = target,
+                    Assignments = assignments,
+                    Where = where,
+                    Returning = returning,
+                    ReturningInto = returningInto,
+                    From = from,
+                };
     }
 
     protected virtual SqlNode VisitDelete(DeleteStatement node)
@@ -148,12 +230,23 @@ public abstract class SqlRewriter
         var target = Visit(node.Target);
         var where = VisitOptional(node.Where);
         var returning = VisitOptionalList(node.Returning);
+        var returningInto = VisitOptionalList(node.ReturningInto);
+        var usingSource = VisitOptional(node.Using);
 
         return ReferenceEquals(target, node.Target)
             && ReferenceEquals(where, node.Where)
             && ReferenceEquals(returning, node.Returning)
+            && ReferenceEquals(returningInto, node.ReturningInto)
+            && ReferenceEquals(usingSource, node.Using)
                 ? node
-                : node with { Target = target, Where = where, Returning = returning };
+                : node with
+                {
+                    Target = target,
+                    Where = where,
+                    Returning = returning,
+                    ReturningInto = returningInto,
+                    Using = usingSource,
+                };
     }
 
     protected virtual SqlNode VisitIdentifier(SqlIdentifier node) => node;
@@ -223,9 +316,20 @@ public abstract class SqlRewriter
     {
         var name = Visit(node.Name);
         var arguments = VisitList(node.Arguments);
-        return ReferenceEquals(name, node.Name) && ReferenceEquals(arguments, node.Arguments)
+        var filter = VisitOptional(node.Filter);
+        var withinGroup = VisitOptionalList(node.WithinGroup);
+        return ReferenceEquals(name, node.Name)
+            && ReferenceEquals(arguments, node.Arguments)
+            && ReferenceEquals(filter, node.Filter)
+            && ReferenceEquals(withinGroup, node.WithinGroup)
             ? node
-            : node with { Name = name, Arguments = arguments };
+            : node with
+            {
+                Name = name,
+                Arguments = arguments,
+                Filter = filter,
+                WithinGroup = withinGroup,
+            };
     }
 
     protected virtual SqlNode VisitWindow(WindowExpression node)
@@ -233,11 +337,22 @@ public abstract class SqlRewriter
         var expression = Visit(node.Expression);
         var partitionBy = VisitOptionalList(node.PartitionBy);
         var orderBy = VisitOptionalList(node.OrderBy);
+        var frame = VisitOptional(node.Frame);
+        var windowName = VisitOptional(node.WindowName);
         return ReferenceEquals(expression, node.Expression)
             && ReferenceEquals(partitionBy, node.PartitionBy)
             && ReferenceEquals(orderBy, node.OrderBy)
+            && ReferenceEquals(frame, node.Frame)
+            && ReferenceEquals(windowName, node.WindowName)
                 ? node
-                : node with { Expression = expression, PartitionBy = partitionBy, OrderBy = orderBy };
+                : node with
+                {
+                    Expression = expression,
+                    PartitionBy = partitionBy,
+                    OrderBy = orderBy,
+                    Frame = frame,
+                    WindowName = windowName,
+                };
     }
 
     protected virtual SqlNode VisitExists(ExistsExpression node) =>
@@ -305,11 +420,13 @@ public abstract class SqlRewriter
         var left = Visit(node.Left);
         var right = Visit(node.Right);
         var condition = VisitOptional(node.Condition);
+        var usingColumns = VisitOptionalList(node.Using);
         return ReferenceEquals(left, node.Left)
             && ReferenceEquals(right, node.Right)
             && ReferenceEquals(condition, node.Condition)
+            && ReferenceEquals(usingColumns, node.Using)
                 ? node
-                : node with { Left = left, Right = right, Condition = condition };
+                : node with { Left = left, Right = right, Condition = condition, Using = usingColumns };
     }
 
     protected virtual SqlNode VisitSelectItem(SelectItem node)

--- a/src/Cyqwel/Visitors/SqlVisitor.Standard.cs
+++ b/src/Cyqwel/Visitors/SqlVisitor.Standard.cs
@@ -1,0 +1,48 @@
+using Cyqwel.Ast;
+
+namespace Cyqwel.Visitors;
+
+public abstract partial class SqlVisitor
+{
+    protected virtual void VisitValues(ValuesStatement node) => DefaultVisit(node);
+    protected virtual void VisitMerge(MergeStatement node) => DefaultVisit(node);
+    protected virtual void VisitCreateTable(CreateTableStatement node) => DefaultVisit(node);
+    protected virtual void VisitAlterTable(AlterTableStatement node) => DefaultVisit(node);
+    protected virtual void VisitDrop(DropStatement node) => DefaultVisit(node);
+    protected virtual void VisitTruncate(TruncateStatement node) => DefaultVisit(node);
+    protected virtual void VisitCreateView(CreateViewStatement node) => DefaultVisit(node);
+    protected virtual void VisitCreateIndex(CreateIndexStatement node) => DefaultVisit(node);
+    protected virtual void VisitCreateSequence(CreateSequenceStatement node) => DefaultVisit(node);
+    protected virtual void VisitAlterSequence(AlterSequenceStatement node) => DefaultVisit(node);
+    protected virtual void VisitBooleanTest(BooleanTestExpression node) => DefaultVisit(node);
+    protected virtual void VisitDistinctFrom(DistinctFromExpression node) => DefaultVisit(node);
+    protected virtual void VisitRow(RowExpression node) => DefaultVisit(node);
+    protected virtual void VisitDefault(DefaultExpression node) => DefaultVisit(node);
+    protected virtual void VisitCollate(CollateExpression node) => DefaultVisit(node);
+    protected virtual void VisitExtract(ExtractExpression node) => DefaultVisit(node);
+    protected virtual void VisitInterval(IntervalExpression node) => DefaultVisit(node);
+    protected virtual void VisitSequenceValue(SequenceValueExpression node) => DefaultVisit(node);
+    protected virtual void VisitTryCast(TryCastExpression node) => DefaultVisit(node);
+    protected virtual void VisitWindowDefinition(WindowDefinition node) => DefaultVisit(node);
+    protected virtual void VisitWindowFrame(WindowFrame node) => DefaultVisit(node);
+    protected virtual void VisitWindowFrameBound(WindowFrameBound node) => DefaultVisit(node);
+    protected virtual void VisitConnectBy(ConnectByClause node) => DefaultVisit(node);
+    protected virtual void VisitMergeWhen(MergeWhenClause node) => DefaultVisit(node);
+    protected virtual void VisitMergeUpdate(MergeUpdateAction node) => DefaultVisit(node);
+    protected virtual void VisitMergeInsert(MergeInsertAction node) => DefaultVisit(node);
+    protected virtual void VisitMergeDelete(MergeDeleteAction node) => DefaultVisit(node);
+    protected virtual void VisitColumnDefinition(ColumnDefinition node) => DefaultVisit(node);
+    protected virtual void VisitPrimaryKeyConstraint(PrimaryKeyConstraint node) => DefaultVisit(node);
+    protected virtual void VisitUniqueConstraint(UniqueConstraint node) => DefaultVisit(node);
+    protected virtual void VisitForeignKeyConstraint(ForeignKeyConstraint node) => DefaultVisit(node);
+    protected virtual void VisitCheckConstraint(CheckConstraint node) => DefaultVisit(node);
+    protected virtual void VisitAddColumn(AddColumnAction node) => DefaultVisit(node);
+    protected virtual void VisitDropColumn(DropColumnAction node) => DefaultVisit(node);
+    protected virtual void VisitAlterColumn(AlterColumnAction node) => DefaultVisit(node);
+    protected virtual void VisitAddConstraint(AddConstraintAction node) => DefaultVisit(node);
+    protected virtual void VisitDropConstraint(DropConstraintAction node) => DefaultVisit(node);
+    protected virtual void VisitRenameColumn(RenameColumnAction node) => DefaultVisit(node);
+    protected virtual void VisitRenameTable(RenameTableAction node) => DefaultVisit(node);
+    protected virtual void VisitIndexColumn(IndexColumn node) => DefaultVisit(node);
+    protected virtual void VisitSequenceOptions(SequenceOptions node) => DefaultVisit(node);
+}

--- a/src/Cyqwel/Visitors/SqlVisitor.cs
+++ b/src/Cyqwel/Visitors/SqlVisitor.cs
@@ -5,7 +5,7 @@ namespace Cyqwel.Visitors;
 /// <summary>
 /// Traverses SQL nodes without modifying them. Override typed methods to analyze selected nodes.
 /// </summary>
-public abstract class SqlVisitor
+public abstract partial class SqlVisitor
 {
     public virtual void Visit(SqlNode node)
     {
@@ -15,10 +15,20 @@ public abstract class SqlVisitor
         {
             case SqlDocument value: VisitDocument(value); break;
             case SelectStatement value: VisitSelect(value); break;
+            case ValuesStatement value: VisitValues(value); break;
             case SetOperationStatement value: VisitSetOperation(value); break;
             case InsertStatement value: VisitInsert(value); break;
             case UpdateStatement value: VisitUpdate(value); break;
             case DeleteStatement value: VisitDelete(value); break;
+            case MergeStatement value: VisitMerge(value); break;
+            case CreateTableStatement value: VisitCreateTable(value); break;
+            case AlterTableStatement value: VisitAlterTable(value); break;
+            case DropStatement value: VisitDrop(value); break;
+            case TruncateStatement value: VisitTruncate(value); break;
+            case CreateViewStatement value: VisitCreateView(value); break;
+            case CreateIndexStatement value: VisitCreateIndex(value); break;
+            case CreateSequenceStatement value: VisitCreateSequence(value); break;
+            case AlterSequenceStatement value: VisitAlterSequence(value); break;
             case SqlIdentifier value: VisitIdentifier(value); break;
             case ColumnExpression value: VisitColumn(value); break;
             case StarExpression value: VisitStar(value); break;
@@ -30,6 +40,14 @@ public abstract class SqlVisitor
             case BetweenExpression value: VisitBetween(value); break;
             case InExpression value: VisitIn(value); break;
             case IsNullExpression value: VisitIsNull(value); break;
+            case BooleanTestExpression value: VisitBooleanTest(value); break;
+            case DistinctFromExpression value: VisitDistinctFrom(value); break;
+            case RowExpression value: VisitRow(value); break;
+            case DefaultExpression value: VisitDefault(value); break;
+            case CollateExpression value: VisitCollate(value); break;
+            case ExtractExpression value: VisitExtract(value); break;
+            case IntervalExpression value: VisitInterval(value); break;
+            case SequenceValueExpression value: VisitSequenceValue(value); break;
             case FunctionCallExpression value: VisitFunctionCall(value); break;
             case WindowExpression value: VisitWindow(value); break;
             case ExistsExpression value: VisitExists(value); break;
@@ -37,6 +55,7 @@ public abstract class SqlVisitor
             case WhenClause value: VisitWhen(value); break;
             case CaseExpression value: VisitCase(value); break;
             case CastExpression value: VisitCast(value); break;
+            case TryCastExpression value: VisitTryCast(value); break;
             case SqlDataType value: VisitDataType(value); break;
             case TableName value: VisitTableName(value); break;
             case NamedTable value: VisitNamedTable(value); break;
@@ -46,6 +65,28 @@ public abstract class SqlVisitor
             case OrderByItem value: VisitOrderByItem(value); break;
             case CommonTableExpression value: VisitCommonTableExpression(value); break;
             case Assignment value: VisitAssignment(value); break;
+            case WindowDefinition value: VisitWindowDefinition(value); break;
+            case WindowFrame value: VisitWindowFrame(value); break;
+            case WindowFrameBound value: VisitWindowFrameBound(value); break;
+            case ConnectByClause value: VisitConnectBy(value); break;
+            case MergeWhenClause value: VisitMergeWhen(value); break;
+            case MergeUpdateAction value: VisitMergeUpdate(value); break;
+            case MergeInsertAction value: VisitMergeInsert(value); break;
+            case MergeDeleteAction value: VisitMergeDelete(value); break;
+            case ColumnDefinition value: VisitColumnDefinition(value); break;
+            case PrimaryKeyConstraint value: VisitPrimaryKeyConstraint(value); break;
+            case UniqueConstraint value: VisitUniqueConstraint(value); break;
+            case ForeignKeyConstraint value: VisitForeignKeyConstraint(value); break;
+            case CheckConstraint value: VisitCheckConstraint(value); break;
+            case AddColumnAction value: VisitAddColumn(value); break;
+            case DropColumnAction value: VisitDropColumn(value); break;
+            case AlterColumnAction value: VisitAlterColumn(value); break;
+            case AddConstraintAction value: VisitAddConstraint(value); break;
+            case DropConstraintAction value: VisitDropConstraint(value); break;
+            case RenameColumnAction value: VisitRenameColumn(value); break;
+            case RenameTableAction value: VisitRenameTable(value); break;
+            case IndexColumn value: VisitIndexColumn(value); break;
+            case SequenceOptions value: VisitSequenceOptions(value); break;
             default: throw new NotSupportedException($"Unsupported SQL node type '{node.GetType().Name}'.");
         }
     }

--- a/tests/Cyqwel.Tests/OracleDialectTests.cs
+++ b/tests/Cyqwel.Tests/OracleDialectTests.cs
@@ -1,0 +1,88 @@
+using Cyqwel.Ast;
+using Cyqwel.Dialects;
+using Cyqwel.Visitors;
+
+namespace Cyqwel.Tests;
+
+public class OracleDialectTests
+{
+    [Fact]
+    public void Registers_oracle_as_a_builtin_dialect()
+    {
+        Assert.Same(SqlDialects.Oracle, SqlDialectRegistry.Get("oracle"));
+        Assert.Contains(SqlDialects.Oracle, SqlDialects.BuiltIn);
+    }
+
+    [Fact]
+    public void Parses_oracle_hierarchical_queries_sequences_and_row_limits()
+    {
+        const string sql = """
+            SELECT employee_seq.NEXTVAL, e.employee_id
+            FROM employees e
+            START WITH e.manager_id IS NULL
+            CONNECT BY NOCYCLE PRIOR e.employee_id = e.manager_id
+            ORDER SIBLINGS BY e.employee_id
+            OFFSET 5 ROWS FETCH NEXT 10 ROWS ONLY
+            """;
+        var document = SqlDialects.Oracle.Parse(sql);
+        var select = Assert.IsType<SelectStatement>(Assert.Single(document.Statements));
+
+        Assert.Single(document.FindAll<SequenceValueExpression>());
+        Assert.NotNull(select.ConnectBy);
+        Assert.True(select.ConnectBy.NoCycle);
+        Assert.True(select.OrderSiblings);
+        Assert.Equal(
+            "SELECT employee_seq.NEXTVAL, e.employee_id FROM employees e START WITH e.manager_id IS NULL CONNECT BY NOCYCLE PRIOR e.employee_id = e.manager_id ORDER SIBLINGS BY e.employee_id OFFSET 5 ROWS FETCH FIRST 10 ROWS ONLY",
+            document.ToSql(SqlDialects.Oracle));
+    }
+
+    [Fact]
+    public void Parses_oracle_returning_into_and_bind_variables()
+    {
+        var document = SqlDialects.Oracle.Parse(
+            "UPDATE users u SET u.name = :name WHERE u.id = :id RETURNING u.id INTO :result");
+        var update = Assert.IsType<UpdateStatement>(Assert.Single(document.Statements));
+
+        Assert.Single(update.Returning!);
+        Assert.Single(update.ReturningInto!);
+        Assert.All(document.FindAll<ParameterExpression>(), value => Assert.Equal(':', value.Prefix));
+        Assert.Equal(
+            "UPDATE users u SET u.name = :name WHERE u.id = :id RETURNING u.id INTO :result",
+            document.ToSql(SqlDialects.Oracle));
+    }
+
+    [Fact]
+    public void Generates_oracle_set_operators_functions_and_aliases()
+    {
+        var set = new SetOperationStatement(
+            new SelectStatement(
+                [new SelectItem(new FunctionCallExpression("COALESCE", new ColumnExpression("name"), new LiteralExpression("n/a")))],
+                new NamedTable("current_users", "u")),
+            SetOperator.Except,
+            new SelectStatement(
+                [new SelectItem(new ColumnExpression("name"))],
+                new NamedTable("archived_users", "a")));
+
+        Assert.Equal(
+            "SELECT NVL(name, 'n/a') FROM current_users u MINUS SELECT name FROM archived_users a",
+            set.ToSql(SqlDialects.Oracle));
+
+        Assert.Equal(
+            "SELECT id FROM users WHERE id = :id",
+            SqlDialects.Generic.Transpile(
+                "SELECT id FROM users WHERE id = @id",
+                SqlDialects.Oracle));
+    }
+
+    [Fact]
+    public void Parses_and_generates_oracle_sequences()
+    {
+        var document = SqlDialects.Oracle.Parse(
+            "CREATE SEQUENCE account_seq START WITH 100 INCREMENT BY 10 CACHE 50 NO CYCLE");
+
+        Assert.IsType<CreateSequenceStatement>(Assert.Single(document.Statements));
+        Assert.Equal(
+            "CREATE SEQUENCE account_seq START WITH 100 INCREMENT BY 10 CACHE 50 NO CYCLE",
+            document.ToSql(SqlDialects.Oracle));
+    }
+}

--- a/tests/Cyqwel.Tests/ParserCoverageTests.cs
+++ b/tests/Cyqwel.Tests/ParserCoverageTests.cs
@@ -1,0 +1,325 @@
+using System.Reflection;
+using Cyqwel.Ast;
+using Cyqwel.Dialects;
+using Cyqwel.Parsing;
+using Cyqwel.Visitors;
+using Parlot;
+
+namespace Cyqwel.Tests;
+
+public class ParserCoverageTests
+{
+    [Fact]
+    public void Covers_remaining_expression_and_query_forms()
+    {
+        var document = SqlParser.Parse("""
+            SELECT seq.CURRVAL,
+                   TRY_CAST('1' AS INTEGER),
+                   EXTRACT(YEAR FROM created_at),
+                   INTERVAL '1' DAY,
+                   NOT EXISTS (SELECT 1),
+                   (SELECT 1),
+                   ROW(1, 2),
+                   d.*,
+                   CONNECT_BY_ROOT id,
+                   8 / 2,
+                   2 * 3,
+                   5 + 3,
+                   5 - 3,
+                   1 <= 2,
+                   1 <> 2,
+                   1 != 2,
+                   1 < 2,
+                   CASE WHEN 1 = 1 THEN 'yes' ELSE 'no' END,
+                   name COLLATE ordinal
+            FROM (SELECT 1 AS id) d
+            WHERE id IN (1, 2)
+              AND name LIKE 'a%'
+              AND name NOT ILIKE 'b%'
+            """);
+
+        Assert.Single(document.FindAll<SequenceValueExpression>());
+        Assert.Single(document.FindAll<TryCastExpression>());
+        Assert.Single(document.FindAll<ExtractExpression>());
+        Assert.Single(document.FindAll<IntervalExpression>());
+        Assert.Single(document.FindAll<ExistsExpression>());
+        Assert.Single(document.FindAll<SubqueryExpression>());
+        Assert.Single(document.FindAll<RowExpression>());
+        Assert.Single(document.FindAll<StarExpression>());
+        Assert.Single(document.FindAll<DerivedTable>());
+        Assert.Contains(
+            document.FindAll<UnaryExpression>(),
+            value => value.Operator == UnaryOperator.ConnectByRoot);
+        Assert.Contains(
+            document.FindAll<InExpression>(),
+            value => value.Values.Count == 2);
+        Assert.Contains(
+            document.FindAll<CaseExpression>(),
+            value => value.Else is not null);
+        Assert.Single(document.FindAll<CollateExpression>());
+    }
+
+    [Fact]
+    public void Covers_all_window_frame_bounds_and_units()
+    {
+        var document = SqlParser.Parse("""
+            SELECT SUM(value) OVER (ORDER BY id ROWS 2 FOLLOWING),
+                   SUM(value) OVER (ORDER BY id RANGE UNBOUNDED FOLLOWING),
+                   SUM(value) OVER (ORDER BY id GROUPS CURRENT ROW),
+                   SUM(value) OVER (ORDER BY id ASC NULLS FIRST)
+            FROM entries
+            """);
+        var frames = document.FindAll<WindowFrame>().ToArray();
+
+        Assert.Equal(3, frames.Length);
+        Assert.Contains(frames, value => value.Start.Kind == WindowFrameBoundKind.Following);
+        Assert.Contains(frames, value => value.Start.Kind == WindowFrameBoundKind.UnboundedFollowing);
+        Assert.Contains(frames, value => value.Unit == WindowFrameUnit.Groups);
+    }
+
+    [Fact]
+    public void Covers_optional_select_and_cte_clauses()
+    {
+        var hierarchy = SqlParser.Parse("""
+            SELECT id
+            FROM nodes
+            QUALIFY id > 0
+            CONNECT BY PRIOR id = parent_id
+            """);
+        var with = SqlParser.Parse("""
+            WITH cached AS MATERIALIZED (SELECT 1),
+                 inline AS NOT MATERIALIZED (SELECT 2)
+            SELECT 1
+            """);
+
+        var select = Assert.IsType<SelectStatement>(Assert.Single(hierarchy.Statements));
+        Assert.NotNull(select.ConnectBy);
+        Assert.Null(select.ConnectBy.StartWith);
+        Assert.False(select.ConnectBy.NoCycle);
+        Assert.NotNull(select.Qualify);
+        Assert.Equal(
+            [CteMaterialization.Materialized, CteMaterialization.NotMaterialized],
+            Assert.IsType<SelectStatement>(Assert.Single(with.Statements))
+                .CommonTableExpressions!
+                .Select(value => value.Materialization));
+    }
+
+    [Fact]
+    public void Covers_optional_insert_and_merge_clauses()
+    {
+        var document = SqlParser.Parse("""
+            INSERT INTO audit VALUES (1) RETURNING id INTO @inserted;
+            MERGE INTO target t
+            USING source s
+            ON t.id = s.id
+            WHEN MATCHED THEN UPDATE SET t.name = s.name DELETE WHERE s.deleted IS TRUE
+            WHEN NOT MATCHED BY SOURCE THEN DELETE
+            WHEN NOT MATCHED THEN INSERT VALUES (s.id, s.name)
+            RETURNING t.id INTO @merged
+            """);
+        var insert = Assert.IsType<InsertStatement>(document.Statements[0]);
+        var merge = Assert.IsType<MergeStatement>(document.Statements[1]);
+
+        Assert.Null(insert.Columns);
+        Assert.NotNull(insert.Values);
+        Assert.Single(insert.ReturningInto!);
+        Assert.NotNull(Assert.IsType<MergeUpdateAction>(merge.WhenClauses[0].Action).DeleteWhere);
+        Assert.Equal(MergeMatchKind.NotMatchedBySource, merge.WhenClauses[1].MatchKind);
+        Assert.Null(Assert.IsType<MergeInsertAction>(merge.WhenClauses[2].Action).Columns);
+        Assert.Single(merge.ReturningInto!);
+    }
+
+    [Fact]
+    public void Covers_all_column_constraint_and_view_variants()
+    {
+        var document = SqlParser.Parse("""
+            CREATE TABLE generated_columns (
+                nullable_value INTEGER NULL,
+                virtual_value INTEGER GENERATED ALWAYS AS (nullable_value + 1),
+                stored_value INTEGER GENERATED ALWAYS AS (nullable_value + 2) STORED,
+                PRIMARY KEY (nullable_value),
+                CONSTRAINT fk_parent FOREIGN KEY (nullable_value) REFERENCES parent (id)
+            );
+            CREATE OR REPLACE TEMPORARY VIEW generated_view (id) AS SELECT nullable_value FROM generated_columns
+            """);
+        var columns = document.FindAll<ColumnDefinition>().ToArray();
+        var view = Assert.Single(document.FindAll<CreateViewStatement>());
+
+        Assert.Contains(columns, value => value.Nullability == Nullability.Null);
+        Assert.Contains(columns, value => value.GeneratedExpression is not null
+            && value.GeneratedKind == GeneratedColumnKind.Virtual);
+        Assert.Contains(columns, value => value.GeneratedKind == GeneratedColumnKind.Stored);
+        Assert.Single(document.FindAll<PrimaryKeyConstraint>());
+        Assert.Single(document.FindAll<ForeignKeyConstraint>());
+        Assert.True(view.OrReplace);
+        Assert.True(view.IsTemporary);
+        Assert.Single(view.Columns!);
+    }
+
+    [Fact]
+    public void Covers_sequence_and_alter_table_variants()
+    {
+        var document = SqlParser.Parse("""
+            CREATE SEQUENCE complete_seq MINVALUE 1 MAXVALUE 999 CYCLE;
+            ALTER SEQUENCE complete_seq START WITH 2 INCREMENT BY 3;
+            ALTER TABLE child ADD CONSTRAINT child_pk PRIMARY KEY (id);
+            ALTER TABLE child DROP COLUMN IF EXISTS obsolete CASCADE;
+            ALTER TABLE child DROP CONSTRAINT IF EXISTS old_constraint CASCADE;
+            ALTER TABLE child RENAME COLUMN old_name TO new_name;
+            ALTER TABLE child RENAME TO children
+            """);
+        var sequence = Assert.Single(document.FindAll<CreateSequenceStatement>());
+
+        Assert.NotNull(sequence.Options.MinimumValue);
+        Assert.NotNull(sequence.Options.MaximumValue);
+        Assert.True(sequence.Options.Cycle);
+        Assert.Single(document.FindAll<AlterSequenceStatement>());
+        Assert.Single(document.FindAll<AddConstraintAction>());
+        Assert.Single(document.FindAll<DropColumnAction>());
+        Assert.Single(document.FindAll<DropConstraintAction>());
+        Assert.Single(document.FindAll<RenameColumnAction>());
+        Assert.Single(document.FindAll<RenameTableAction>());
+    }
+
+    [Fact]
+    public void Covers_optional_ddl_clauses()
+    {
+        var document = SqlParser.Parse("""
+            CREATE TEMPORARY TABLE IF NOT EXISTS copied AS SELECT 1;
+            CREATE TABLE constraints (
+                id INTEGER,
+                UNIQUE (id),
+                FOREIGN KEY (id) REFERENCES parent (id),
+                CHECK (id > 0)
+            );
+            CREATE VIEW simple_view AS SELECT 1;
+            CREATE INDEX filtered_index ON constraints (id DESC NULLS LAST) WHERE id > 0
+            """);
+        var copied = Assert.IsType<CreateTableStatement>(document.Statements[0]);
+        var view = Assert.IsType<CreateViewStatement>(document.Statements[2]);
+        var index = Assert.IsType<CreateIndexStatement>(document.Statements[3]);
+
+        Assert.True(copied.IfNotExists);
+        Assert.True(copied.IsTemporary);
+        Assert.Empty(copied.Elements);
+        Assert.NotNull(copied.AsQuery);
+        Assert.Single(document.FindAll<UniqueConstraint>());
+        Assert.Single(document.FindAll<ForeignKeyConstraint>());
+        Assert.Single(document.FindAll<CheckConstraint>());
+        Assert.Null(view.Columns);
+        Assert.Equal(OrderDirection.Descending, Assert.Single(index.Columns).Direction);
+        Assert.Equal(NullOrder.Last, Assert.Single(index.Columns).NullOrder);
+        Assert.NotNull(index.Where);
+    }
+
+    [Fact]
+    public void Covers_parser_configuration_without_limits_or_parameters()
+    {
+        var dialect = SqlDialectBuilder.Create($"minimal-{Guid.NewGuid():N}")
+            .ConfigureParser(options => options with
+            {
+                ParameterStyles = SqlParameterStyle.None,
+                SupportsTop = false,
+                SupportsLimit = false,
+                SupportsLimitComma = false,
+                SupportsOffsetOnly = false,
+                SupportsOffsetFetch = false,
+            })
+            .Build();
+
+        Assert.Equal("SELECT 1", dialect.Parse("SELECT 1").ToSql(dialect));
+        Assert.Throws<SqlParseException>(() => dialect.Parse("SELECT @id"));
+    }
+
+    [Fact]
+    public void Covers_dollar_sign_identifier_configuration()
+    {
+        var dialect = SqlDialectBuilder.Create($"dollar-identifiers-{Guid.NewGuid():N}")
+            .ConfigureParser(options => options with
+            {
+                DollarSignIsIdentifier = true,
+            })
+            .Build();
+        var document = dialect.Parse("SELECT cash$value FROM data$table WHERE cash$value = @arg$value");
+
+        Assert.Contains(
+            document.FindAll<SqlIdentifier>(),
+            value => value.Value == "cash$value");
+        Assert.Contains(
+            document.FindAll<SqlIdentifier>(),
+            value => value.Value == "data$table");
+        Assert.Equal("arg$value", Assert.Single(document.FindAll<ParameterExpression>()).Name);
+    }
+
+    [Fact]
+    public void Covers_set_offset_compatibility_paths()
+    {
+        Assert.NotNull(SqlDialects.TSql.Parse(
+            "SELECT id FROM users UNION SELECT id FROM archived"));
+        Assert.NotNull(SqlDialects.TSql.Parse(
+            "SELECT id FROM users UNION SELECT id FROM archived ORDER BY id OFFSET 1 ROWS"));
+
+        var parsed = SqlDialects.TSql.TryParse(
+            "SELECT id FROM users UNION SELECT id FROM archived OFFSET 1 ROWS",
+            out _,
+            out var error);
+
+        Assert.False(parsed);
+        Assert.Equal(SqlParseErrorCode.DialectIncompatible, error!.Code);
+    }
+
+    [Fact]
+    public void Covers_escape_and_empty_error_fallbacks()
+    {
+        var escaped = SqlDialects.MySql.Parse("""SELECT '\\'""");
+        var literal = Assert.Single(escaped.FindAll<LiteralExpression>());
+
+        Assert.Equal("\\", literal.Value);
+        Assert.False(SqlParser.TryParse("", SqlDialects.Generic, out _, out var error));
+        Assert.Equal(SqlParseErrorCode.Syntax, error!.Code);
+    }
+
+    [Fact]
+    public void Covers_defensive_unknown_query_paths()
+    {
+        var query = new UnknownQuery();
+        var applyTail = GetParserMethod("ApplyQueryTail");
+        var applyCtes = GetParserMethod("ApplyCommonTableExpressions");
+        var toParseError = GetParserMethod("ToParseError");
+        var getParseErrorMessage = GetParserMethod("GetParseErrorMessage");
+
+        Assert.Same(query, applyTail.Invoke(null, [query, null, null]));
+        Assert.Same(
+            query,
+            applyCtes.Invoke(
+                null,
+                [query, Array.Empty<CommonTableExpression>(), false]));
+        var error = Assert.IsType<SqlParseError>(
+            toParseError.Invoke(null, ["fallback", null, SqlParseErrorCode.Syntax]));
+        Assert.Equal(0, error.Offset);
+        Assert.Equal(1, error.Line);
+        Assert.Equal(1, error.Column);
+
+        var parlotError = new ParseError
+        {
+            Message = "detailed",
+            Position = new TextPosition(4, 2, 3),
+        };
+        var detailed = Assert.IsType<SqlParseError>(
+            toParseError.Invoke(null, ["fallback", parlotError, SqlParseErrorCode.Syntax]));
+        Assert.Equal(4, detailed.Offset);
+        Assert.Equal(2, detailed.Line);
+        Assert.Equal(3, detailed.Column);
+        Assert.Equal("Invalid SQL.", getParseErrorMessage.Invoke(null, [null]));
+        Assert.Equal(
+            "Invalid SQL.",
+            getParseErrorMessage.Invoke(null, [new ParseError()]));
+        Assert.Equal("detailed", getParseErrorMessage.Invoke(null, [parlotError]));
+    }
+
+    private static MethodInfo GetParserMethod(string name) =>
+        typeof(SqlParser).GetMethod(name, BindingFlags.Static | BindingFlags.NonPublic)
+        ?? throw new InvalidOperationException($"Parser method '{name}' was not found.");
+
+    private sealed record UnknownQuery : SqlQuery;
+}

--- a/tests/Cyqwel.Tests/ParserTests.cs
+++ b/tests/Cyqwel.Tests/ParserTests.cs
@@ -48,10 +48,9 @@ public class ParserTests
 
         var document = SqlParser.Parse(sql);
         var set = Assert.IsType<SetOperationStatement>(Assert.Single(document.Statements));
-        var left = Assert.IsType<SelectStatement>(set.Left);
 
         Assert.True(set.IsAll);
-        Assert.Single(left.CommonTableExpressions!);
+        Assert.Single(set.CommonTableExpressions!);
         Assert.Single(set.OrderBy!);
         Assert.Equal(5L, Assert.IsType<LiteralExpression>(set.Limit).Value);
     }

--- a/tests/Cyqwel.Tests/StandardSqlExpansionTests.cs
+++ b/tests/Cyqwel.Tests/StandardSqlExpansionTests.cs
@@ -1,0 +1,272 @@
+using Cyqwel.Ast;
+using Cyqwel.Dialects;
+using Cyqwel.Parsing;
+using Cyqwel.Visitors;
+
+namespace Cyqwel.Tests;
+
+public class StandardSqlExpansionTests
+{
+    [Fact]
+    public void Parses_values_richer_joins_and_predicates()
+    {
+        var values = SqlParser.Parse(
+            "VALUES (1, 'one'), (2, 'two') ORDER BY 1 FETCH FIRST 1 ROWS ONLY");
+        var query = Assert.IsType<ValuesStatement>(Assert.Single(values.Statements));
+
+        Assert.Equal(2, query.Rows.Count);
+        Assert.Equal("VALUES (1, 'one'), (2, 'two') ORDER BY 1 LIMIT 1", values.ToSql());
+
+        var select = SqlParser.Parse("""
+            SELECT a.id
+            FROM a
+            NATURAL LEFT JOIN b
+            INNER JOIN c USING (id)
+            WHERE a.active IS TRUE
+              AND a.value IS DISTINCT FROM b.value
+            """);
+
+        Assert.Single(select.FindAll<BooleanTestExpression>());
+        Assert.Single(select.FindAll<DistinctFromExpression>());
+        Assert.Contains(select.FindAll<JoinTable>(), join => join.IsNatural);
+        Assert.Contains(select.FindAll<JoinTable>(), join => join.Using is { Count: 1 });
+    }
+
+    [Fact]
+    public void Parses_aggregate_modifiers_and_window_frames()
+    {
+        var document = SqlParser.Parse("""
+            SELECT SUM(amount) WITHIN GROUP (ORDER BY created_at)
+                     FILTER (WHERE amount > 0)
+                     OVER (
+                         PARTITION BY account_id
+                         ORDER BY created_at
+                         ROWS BETWEEN 2 PRECEDING AND CURRENT ROW
+                     )
+            FROM entries
+            WINDOW totals AS (PARTITION BY account_id ORDER BY created_at)
+            """);
+        var function = Assert.Single(document.FindAll<FunctionCallExpression>());
+        var window = Assert.Single(document.FindAll<WindowExpression>());
+        var definition = Assert.Single(document.FindAll<WindowDefinition>());
+
+        Assert.NotNull(function.Filter);
+        Assert.Single(function.WithinGroup!);
+        Assert.NotNull(window.Frame);
+        Assert.Equal(WindowFrameBoundKind.Preceding, window.Frame.Start.Kind);
+        Assert.Equal(WindowFrameBoundKind.CurrentRow, window.Frame.End!.Kind);
+        Assert.Equal("totals", definition.Name.Value);
+    }
+
+    [Fact]
+    public void Parses_merge_and_extended_dml()
+    {
+        var merge = SqlParser.Parse("""
+            MERGE INTO target t
+            USING source s
+            ON t.id = s.id
+            WHEN MATCHED AND s.deleted IS TRUE THEN DELETE
+            WHEN MATCHED THEN UPDATE SET t.name = s.name
+            WHEN NOT MATCHED THEN INSERT (id, name) VALUES (s.id, s.name)
+            """);
+        var statement = Assert.IsType<MergeStatement>(Assert.Single(merge.Statements));
+
+        Assert.Equal(3, statement.WhenClauses.Count);
+        Assert.IsType<MergeDeleteAction>(statement.WhenClauses[0].Action);
+        Assert.IsType<MergeUpdateAction>(statement.WhenClauses[1].Action);
+        Assert.IsType<MergeInsertAction>(statement.WhenClauses[2].Action);
+        Assert.Contains("WHEN NOT MATCHED THEN INSERT", merge.ToSql());
+
+        var update = Assert.IsType<UpdateStatement>(Assert.Single(
+            SqlParser.Parse(
+                "UPDATE target SET name = source.name FROM source WHERE target.id = source.id RETURNING target.id INTO @id")
+                .Statements));
+        var delete = Assert.IsType<DeleteStatement>(Assert.Single(
+            SqlParser.Parse(
+                "DELETE FROM target USING source WHERE target.id = source.id RETURNING target.id INTO @id")
+                .Statements));
+
+        Assert.NotNull(update.From);
+        Assert.Single(update.ReturningInto!);
+        Assert.NotNull(delete.Using);
+        Assert.Single(delete.ReturningInto!);
+    }
+
+    [Fact]
+    public void Parses_and_generates_core_ddl()
+    {
+        const string sql = """
+            CREATE TABLE accounts (
+                id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                email VARCHAR(255) NOT NULL UNIQUE,
+                balance DECIMAL(10, 2) DEFAULT 0,
+                CONSTRAINT ck_balance CHECK (balance >= 0),
+                CONSTRAINT uq_email UNIQUE (email)
+            );
+            CREATE UNIQUE INDEX ix_accounts_email ON accounts (email);
+            CREATE SEQUENCE account_seq START WITH 10 INCREMENT BY 5 CACHE 20 NO CYCLE;
+            ALTER TABLE accounts ADD COLUMN status VARCHAR(20) DEFAULT 'active';
+            DROP INDEX IF EXISTS old_accounts_idx;
+            TRUNCATE TABLE archived_accounts CASCADE
+            """;
+        var document = SqlParser.Parse(sql);
+
+        Assert.Collection(
+            document.Statements,
+            value => Assert.IsType<CreateTableStatement>(value),
+            value => Assert.IsType<CreateIndexStatement>(value),
+            value => Assert.IsType<CreateSequenceStatement>(value),
+            value => Assert.IsType<AlterTableStatement>(value),
+            value => Assert.IsType<DropStatement>(value),
+            value => Assert.IsType<TruncateStatement>(value));
+        Assert.Contains("CONSTRAINT ck_balance CHECK (balance >= 0)", document.ToSql());
+        Assert.Contains("CREATE SEQUENCE account_seq START WITH 10 INCREMENT BY 5 CACHE 20 NO CYCLE", document.ToSql());
+    }
+
+    [Fact]
+    public void Traverses_and_rewrites_every_new_node_family()
+    {
+        var id = new SqlIdentifier("id");
+        var dataType = new SqlDataType("INTEGER");
+        var column = new ColumnDefinition(id, dataType, Default: new DefaultExpression());
+        var constraint = new ForeignKeyConstraint(
+            [id],
+            new TableName("parent"),
+            [id])
+        {
+            Name = new SqlIdentifier("fk_parent"),
+        };
+        var frame = new WindowFrame(
+            WindowFrameUnit.Rows,
+            new WindowFrameBound(WindowFrameBoundKind.Preceding, new LiteralExpression(1)),
+            new WindowFrameBound(WindowFrameBoundKind.CurrentRow));
+        var expression = new WindowExpression(
+            new FunctionCallExpression(
+                "SUM",
+                new CollateExpression(new ColumnExpression("amount"), new SqlIdentifier("ordinal"))),
+            Frame: frame);
+        var select = new SelectStatement(
+            [
+                new SelectItem(expression),
+                new SelectItem(new RowExpression([new LiteralExpression(1), new LiteralExpression(2)])),
+                new SelectItem(new ExtractExpression(new SqlIdentifier("YEAR"), new ColumnExpression("created_at"))),
+                new SelectItem(new IntervalExpression(new LiteralExpression(1), new SqlIdentifier("DAY"))),
+                new SelectItem(new SequenceValueExpression(new TableName("seq"), SequenceValueKind.Next)),
+                new SelectItem(new TryCastExpression(new LiteralExpression("1"), dataType)),
+            ],
+            ConnectBy: new ConnectByClause(
+                new UnaryExpression(UnaryOperator.Prior, new ColumnExpression("id"))));
+        var document = new SqlDocument(
+            select,
+            new CreateTableStatement(new TableName("child"), [column, constraint]),
+            new AlterTableStatement(
+                new TableName("child"),
+                [
+                    new AlterColumnAction(id, dataType, Nullability.NotNull),
+                    new AddConstraintAction(new CheckConstraint(new LiteralExpression(true))),
+                    new DropConstraintAction(new SqlIdentifier("old")),
+                    new RenameColumnAction(id, new SqlIdentifier("new_id")),
+                    new RenameTableAction(new SqlIdentifier("children")),
+                ]),
+            new CreateViewStatement(new TableName("child_view"), select),
+            new CreateIndexStatement(
+                new TableName("ix_child"),
+                new TableName("child"),
+                [new IndexColumn(new ColumnExpression("id"))]),
+            new AlterSequenceStatement(
+                new TableName("seq"),
+                new SequenceOptions(IncrementBy: new LiteralExpression(2))));
+
+        var descendants = document.DescendantsAndSelf().ToArray();
+
+        document.Accept(new NoopVisitor());
+        Assert.Same(document, document.Accept(new NoopRewriter()));
+        Assert.Contains(descendants, node => node is WindowFrame);
+        Assert.Contains(descendants, node => node is ForeignKeyConstraint);
+        Assert.Contains(descendants, node => node is AlterColumnAction);
+        Assert.Contains(descendants, node => node is SequenceOptions);
+        Assert.Contains(descendants, node => node is ConnectByClause);
+    }
+
+    private sealed class NoopVisitor : SqlVisitor;
+
+    private sealed class NoopRewriter : SqlRewriter;
+
+    [Fact]
+    public void Preserves_set_precedence_and_root_ctes()
+    {
+        var document = SqlParser.Parse("""
+            WITH ids AS (SELECT id FROM source)
+            SELECT id FROM one
+            UNION
+            SELECT id FROM two
+            INTERSECT
+            SELECT id FROM three
+            """);
+        var union = Assert.IsType<SetOperationStatement>(Assert.Single(document.Statements));
+
+        Assert.Equal(SetOperator.Union, union.Operator);
+        Assert.IsType<SelectStatement>(union.Left);
+        Assert.Equal(
+            SetOperator.Intersect,
+            Assert.IsType<SetOperationStatement>(union.Right).Operator);
+        Assert.Single(union.CommonTableExpressions!);
+        Assert.Equal(
+            "WITH ids AS (SELECT id FROM source) SELECT id FROM one UNION SELECT id FROM two INTERSECT SELECT id FROM three",
+            document.ToSql());
+
+        var values = Assert.IsType<ValuesStatement>(Assert.Single(
+            SqlParser.Parse("WITH ids AS (SELECT id FROM source) VALUES (1)").Statements));
+        Assert.Single(values.CommonTableExpressions!);
+    }
+
+    [Fact]
+    public void Preserves_identity_modes_and_rewritten_constraint_names()
+    {
+        var document = SqlParser.Parse("""
+            CREATE TABLE identities (
+                always_id INTEGER GENERATED ALWAYS AS IDENTITY,
+                default_id INTEGER GENERATED BY DEFAULT AS IDENTITY
+            )
+            """);
+        var create = Assert.IsType<CreateTableStatement>(Assert.Single(document.Statements));
+        var columns = create.Elements.Cast<ColumnDefinition>().ToArray();
+
+        Assert.Equal(IdentityGeneration.Always, columns[0].Identity);
+        Assert.Equal(IdentityGeneration.ByDefault, columns[1].Identity);
+        Assert.Contains("GENERATED ALWAYS AS IDENTITY", document.ToSql());
+        Assert.Contains("GENERATED BY DEFAULT AS IDENTITY", document.ToSql());
+
+        var constraint = new PrimaryKeyConstraint([new SqlIdentifier("id")])
+        {
+            Name = new SqlIdentifier("old_name"),
+        };
+        var rewritten = Assert.IsType<PrimaryKeyConstraint>(
+            constraint.Accept(new RenameConstraintRewriter()));
+
+        Assert.Equal("new_name", rewritten.Name!.Value);
+        Assert.Equal(
+            "CREATE TABLE sample (CONSTRAINT new_name PRIMARY KEY (id))",
+            new CreateTableStatement(new TableName("sample"), [rewritten]).ToSql());
+    }
+
+    [Theory]
+    [InlineData("ALTER TABLE sample ALTER COLUMN value TYPE BIGINT")]
+    [InlineData("ALTER TABLE sample ALTER COLUMN value SET DEFAULT 0")]
+    [InlineData("ALTER TABLE sample ALTER COLUMN value DROP DEFAULT")]
+    [InlineData("ALTER TABLE sample ALTER COLUMN value SET NOT NULL")]
+    [InlineData("ALTER TABLE sample ALTER COLUMN value DROP NOT NULL")]
+    public void Round_trips_alter_column_actions(string sql)
+    {
+        var document = SqlParser.Parse(sql);
+
+        Assert.Single(document.FindAll<AlterColumnAction>());
+        Assert.Equal(sql, document.ToSql());
+    }
+
+    private sealed class RenameConstraintRewriter : SqlRewriter
+    {
+        protected override SqlNode VisitIdentifier(SqlIdentifier node) =>
+            node.Value == "old_name" ? node with { Value = "new_name" } : node;
+    }
+}


### PR DESCRIPTION
Cyqwel's SQL model and parser covered only a subset of the standard relational constructs exercised by Polyglot, which limited round-tripping and cross-dialect translation. This expands the dialect-neutral foundation first and adds Oracle as a built-in relational dialect.

## What changed

- Adds AST, parsing, generation, traversal, and immutable rewriting for richer expressions, windows, joins, CTEs, VALUES, MERGE, and core table/view/index/sequence DDL.
- Correctly models CTE ownership on query roots and applies SQL set-operation precedence, including higher-precedence INTERSECT and associativity-preserving parentheses.
- Adds Oracle quoting and bind parameters, MINUS, FETCH FIRST, hierarchical queries, sequences, RETURNING INTO, and Oracle function transformations.
- Documents the expanded SQL surface and adds focused standard SQL and Oracle regression coverage.
- Reaches 100% line and branch coverage for the primary parser, grammar callbacks, and parser option branches. Compiler-generated equality and printing members on private parser DTO records are excluded from coverage.