### PR TITLE
Add comprehensive SQL validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Cyqwel is a dialect-neutral SQL toolkit for .NET. It parses SQL into an immutabl
 - PostgreSQL `EXPLAIN` options and SQLite date, JSON aggregate, and scalar-function rewrites
 - Oracle bind variables, `MINUS`, sequences, hierarchical queries, row limiting, and native type forms
 - Public dialect base class, registry, and fluent custom dialect builder
+- Syntax, semantic, schema, type, and relationship-aware SQL validation
 - Custom literal and argument-aware function rendering hooks
 - Fluent SELECT, set-operation, INSERT, UPDATE, DELETE, CASE, and expression builders
 - Input and AST complexity guards
@@ -49,6 +50,45 @@ SqlDialects.PostgreSql.Parse("SELECT TOP 10 id FROM users"); // throws SqlParseE
 ```
 
 An otherwise recognized construct that is incompatible with the selected dialect returns `SqlParseErrorCode.DialectIncompatible`. Dialect selection also resolves ambiguous syntax in the source AST; for example, `||` becomes concatenation in PostgreSQL and SQLite but logical `OR` in MySQL.
+
+## Validate SQL
+
+`SqlValidator` returns stable diagnostics with a severity, code, message, and source location when the parser or AST provides one. Warnings do not make `IsValid` false.
+
+```csharp
+using Cyqwel.Validation;
+
+var syntax = SqlValidator.Validate(
+    "SELECT * FROM users LIMIT 10",
+    options: new SqlValidationOptions
+    {
+        StrictSyntax = true,
+        Semantic = true,
+    });
+
+var catalog = new SqlSchemaCatalog(
+    new SqlTableSchema(
+        "users",
+        [
+            new("id", "integer", IsPrimaryKey: true),
+            new("name", "varchar"),
+            new("age", "integer"),
+        ],
+        PrimaryKey: ["id"]));
+
+var schema = SqlValidator.Validate(
+    "SELECT id FROM users WHERE age > 18",
+    catalog,
+    options: new SqlSchemaValidationOptions
+    {
+        CheckTypes = true,
+        CheckReferences = true,
+    });
+```
+
+Semantic validation can flag `SELECT *`, mixed aggregate projections without `GROUP BY`, `DISTINCT` ordering concerns, and non-deterministic `LIMIT`/`OFFSET`. Schema validation resolves tables, aliases, joins, derived tables, and CTE projections. Type checks cover comparisons, arithmetic, predicates, supported function signatures, DML assignments, and set operations. Reference checks validate foreign-key metadata, ambiguous references, cartesian joins, and joins that bypass declared relationships.
+
+Schema, type, and reference findings are errors by default. Set `SqlSchemaValidationOptions.Strict` to `false` to report them as warnings. Diagnostic code constants are available from `SqlValidationCodes`, and schema type names can be normalized with `SqlTypeFamilies.Classify`.
 
 ## Build SQL
 

--- a/src/Cyqwel/Validation/SchemaValidationEngine.cs
+++ b/src/Cyqwel/Validation/SchemaValidationEngine.cs
@@ -1,0 +1,1971 @@
+using Cyqwel.Ast;
+
+namespace Cyqwel.Validation;
+
+internal sealed class SchemaValidationEngine
+{
+    private readonly string _sql;
+    private readonly SqlSchemaValidationOptions _options;
+    private readonly List<SqlValidationDiagnostic> _diagnostics;
+    private readonly CatalogIndex _catalog;
+
+    public SchemaValidationEngine(
+        string sql,
+        SqlSchemaCatalog catalog,
+        SqlSchemaValidationOptions options,
+        List<SqlValidationDiagnostic> diagnostics)
+    {
+        _sql = sql;
+        _options = options;
+        _diagnostics = diagnostics;
+        _catalog = new CatalogIndex(catalog);
+    }
+
+    public void Validate(SqlDocument document)
+    {
+        if (_options.CheckReferences) ValidateForeignKeys();
+
+        var ctes = new Dictionary<string, Projection>(StringComparer.OrdinalIgnoreCase);
+        foreach (var statement in document.Statements)
+        {
+            switch (statement)
+            {
+                case SqlQuery query:
+                    ValidateQuery(query, ctes, null);
+                    break;
+                case ExplainStatement explain:
+                    ValidateQuery(explain.Query, ctes, null);
+                    break;
+                case InsertStatement insert:
+                    ValidateInsert(insert, ctes);
+                    break;
+                case UpdateStatement update:
+                    ValidateUpdate(update, ctes);
+                    break;
+                case DeleteStatement delete:
+                    ValidateDelete(delete, ctes);
+                    break;
+                case MergeStatement merge:
+                    ValidateMerge(merge, ctes);
+                    break;
+            }
+        }
+    }
+
+    private Projection ValidateQuery(
+        SqlQuery query,
+        IReadOnlyDictionary<string, Projection> inheritedCtes,
+        Scope? outerScope)
+    {
+        var ctes = new Dictionary<string, Projection>(
+            inheritedCtes,
+            StringComparer.OrdinalIgnoreCase);
+        var queryCtes = query switch
+        {
+            SelectStatement select => select.CommonTableExpressions,
+            ValuesStatement values => values.CommonTableExpressions,
+            SetOperationStatement set => set.CommonTableExpressions,
+            _ => null,
+        };
+        var recursive = query switch
+        {
+            SelectStatement select => select.IsRecursive,
+            ValuesStatement values => values.IsRecursive,
+            SetOperationStatement set => set.IsRecursive,
+            _ => false,
+        };
+
+        if (queryCtes is not null)
+        {
+            foreach (var cte in queryCtes)
+            {
+                if (recursive)
+                {
+                    ctes[cte.Name.Value] = cte.Columns is { Count: > 0 }
+                        ? new Projection(cte.Columns
+                            .Select(static column =>
+                                new ProjectedColumn(column.Value, SqlTypeFamily.Unknown))
+                            .ToArray())
+                        : InferRecursiveProjection(cte.Query);
+                }
+
+                var projection = ValidateQuery(cte.Query, ctes, outerScope);
+                if (cte.Columns is { Count: > 0 })
+                {
+                    if (cte.Columns.Count != projection.Columns.Count)
+                    {
+                        AddSchemaIssue(
+                            SqlValidationCodes.CteColumnCountMismatch,
+                            $"CTE '{cte.Name.Value}' declares {cte.Columns.Count} columns but projects {projection.Columns.Count}.",
+                            cte);
+                    }
+
+                    projection = new Projection(projection.Columns
+                        .Select((column, index) => index < cte.Columns.Count
+                            ? column with { Name = cte.Columns[index].Value }
+                            : column)
+                        .ToArray());
+                }
+
+                ctes[cte.Name.Value] = projection;
+            }
+        }
+
+        return query switch
+        {
+            SelectStatement select => ValidateSelect(select, ctes, outerScope),
+            ValuesStatement values => ValidateValues(values, ctes, outerScope),
+            SetOperationStatement set => ValidateSetOperation(set, ctes, outerScope),
+            _ => Projection.Empty,
+        };
+    }
+
+    private Projection ValidateSelect(
+        SelectStatement select,
+        IReadOnlyDictionary<string, Projection> ctes,
+        Scope? outerScope)
+    {
+        var scope = new Scope(outerScope);
+        if (select.From is not null) BindTableSource(select.From, scope, ctes);
+
+        var projectedColumns = new List<ProjectedColumn>();
+        foreach (var item in select.Projections)
+        {
+            if (item.Expression is StarExpression star)
+            {
+                ExpandStar(star, scope, projectedColumns);
+                continue;
+            }
+
+            var type = ValidateExpression(item.Expression, scope, ctes);
+            projectedColumns.Add(new ProjectedColumn(
+                item.Alias?.Value ?? InferProjectionName(item.Expression, projectedColumns.Count),
+                type));
+        }
+
+        var projection = new Projection(projectedColumns);
+        var aliases = BuildAliasMap(projection.Columns);
+
+        if (select.Where is not null)
+        {
+            RequirePredicate(select.Where, ValidateExpression(select.Where, scope, ctes));
+        }
+
+        if (select.GroupBy is not null)
+        {
+            foreach (var expression in select.GroupBy)
+            {
+                if (!TryGetAliasType(expression, aliases, out _))
+                {
+                    ValidateExpression(expression, scope, ctes);
+                }
+            }
+        }
+
+        if (select.Having is not null)
+        {
+            RequirePredicate(select.Having, ValidateExpression(select.Having, scope, ctes));
+        }
+
+        if (select.Windows is not null)
+        {
+            foreach (var window in select.Windows)
+            {
+                ValidateExpressions(window.PartitionBy, scope, ctes);
+                ValidateOrderBy(window.OrderBy, scope, ctes, aliases);
+            }
+        }
+
+        if (select.Qualify is not null)
+        {
+            RequirePredicate(select.Qualify, ValidateExpression(select.Qualify, scope, ctes));
+        }
+
+        if (select.ConnectBy is not null)
+        {
+            if (select.ConnectBy.StartWith is not null)
+            {
+                RequirePredicate(
+                    select.ConnectBy.StartWith,
+                    ValidateExpression(select.ConnectBy.StartWith, scope, ctes));
+            }
+
+            RequirePredicate(
+                select.ConnectBy.Condition,
+                ValidateExpression(select.ConnectBy.Condition, scope, ctes));
+        }
+
+        ValidateOrderBy(select.OrderBy, scope, ctes, aliases);
+        ValidateExpressionIfPresent(select.Top, scope, ctes);
+        ValidateExpressionIfPresent(select.Limit, scope, ctes);
+        ValidateExpressionIfPresent(select.Offset, scope, ctes);
+        return projection;
+    }
+
+    private Projection ValidateValues(
+        ValuesStatement values,
+        IReadOnlyDictionary<string, Projection> ctes,
+        Scope? outerScope)
+    {
+        var scope = new Scope(outerScope);
+        var columns = new List<ProjectedColumn>();
+        for (var rowIndex = 0; rowIndex < values.Rows.Count; rowIndex++)
+        {
+            var row = values.Rows[rowIndex];
+            if (rowIndex > 0 && row.Count != columns.Count)
+            {
+                AddTypeIssue(
+                    SqlValidationCodes.SetOperationArityMismatch,
+                    SqlValidationCodes.SetOperationImplicitCoercion,
+                    $"VALUES row {rowIndex + 1} has {row.Count} values; expected {columns.Count}.",
+                    values);
+            }
+
+            for (var columnIndex = 0; columnIndex < row.Count; columnIndex++)
+            {
+                var type = ValidateExpression(row[columnIndex], scope, ctes);
+                if (rowIndex == 0)
+                {
+                    columns.Add(new ProjectedColumn($"column{columnIndex + 1}", type));
+                }
+                else if (columnIndex < columns.Count
+                    && !TypesCompatible(columns[columnIndex].Type, type))
+                {
+                    AddTypeIssue(
+                        SqlValidationCodes.SetOperationTypeMismatch,
+                        SqlValidationCodes.SetOperationImplicitCoercion,
+                        $"VALUES column {columnIndex + 1} mixes {TypeName(columns[columnIndex].Type)} and {TypeName(type)} values.",
+                        row[columnIndex]);
+                }
+            }
+        }
+
+        ValidateOrderBy(values.OrderBy, scope, ctes, null);
+        ValidateExpressionIfPresent(values.Limit, scope, ctes);
+        ValidateExpressionIfPresent(values.Offset, scope, ctes);
+        return new Projection(columns);
+    }
+
+    private Projection ValidateSetOperation(
+        SetOperationStatement set,
+        IReadOnlyDictionary<string, Projection> ctes,
+        Scope? outerScope)
+    {
+        var left = ValidateQuery(set.Left, ctes, outerScope);
+        var right = ValidateQuery(set.Right, ctes, outerScope);
+        if (_options.CheckTypes)
+        {
+            if (left.Columns.Count != right.Columns.Count)
+            {
+                AddTypeIssue(
+                    SqlValidationCodes.SetOperationArityMismatch,
+                    SqlValidationCodes.SetOperationImplicitCoercion,
+                    $"Set operation has {left.Columns.Count} columns on the left and {right.Columns.Count} on the right.",
+                    set);
+            }
+            else
+            {
+                for (var i = 0; i < left.Columns.Count; i++)
+                {
+                    if (!TypesCompatible(left.Columns[i].Type, right.Columns[i].Type))
+                    {
+                        AddTypeIssue(
+                            SqlValidationCodes.SetOperationTypeMismatch,
+                            SqlValidationCodes.SetOperationImplicitCoercion,
+                            $"Set operation column {i + 1} has incompatible {TypeName(left.Columns[i].Type)} and {TypeName(right.Columns[i].Type)} types.",
+                            set);
+                    }
+                }
+            }
+        }
+
+        var scope = new Scope(outerScope);
+        var aliases = BuildAliasMap(left.Columns);
+        ValidateOrderBy(set.OrderBy, scope, ctes, aliases);
+        ValidateExpressionIfPresent(set.Limit, scope, ctes);
+        ValidateExpressionIfPresent(set.Offset, scope, ctes);
+        return left;
+    }
+
+    private IReadOnlyList<SourceBinding> BindTableSource(
+        TableSource source,
+        Scope scope,
+        IReadOnlyDictionary<string, Projection> ctes)
+    {
+        switch (source)
+        {
+            case NamedTable named:
+            {
+                var binding = BindNamedTable(named, ctes);
+                if (!scope.Add(binding))
+                {
+                    AddSchemaIssue(
+                        SqlValidationCodes.UnresolvedReference,
+                        $"Duplicate table alias or qualifier '{binding.Name}'.",
+                        named);
+                }
+
+                return [binding];
+            }
+            case DerivedTable derived:
+            {
+                var projection = ValidateQuery(derived.Query, ctes, scope.Parent);
+                var binding = SourceBinding.FromProjection(
+                    derived.Alias.Value,
+                    projection,
+                    derived.Alias.Value);
+                if (!scope.Add(binding))
+                {
+                    AddSchemaIssue(
+                        SqlValidationCodes.UnresolvedReference,
+                        $"Duplicate table alias or qualifier '{binding.Name}'.",
+                        derived);
+                }
+
+                return [binding];
+            }
+            case JoinTable join:
+            {
+                var left = BindTableSource(join.Left, scope, ctes);
+                var right = BindTableSource(join.Right, scope, ctes);
+                if (join.Condition is not null)
+                {
+                    RequirePredicate(
+                        join.Condition,
+                        ValidateExpression(join.Condition, scope, ctes));
+                }
+
+                if (join.Using is not null)
+                {
+                    foreach (var column in join.Using)
+                    {
+                        ValidateUsingColumn(column, left, right);
+                    }
+                }
+
+                if (_options.CheckReferences)
+                {
+                    if (join.Kind == JoinKind.Cross || join.Syntax == JoinSyntax.Comma)
+                    {
+                        AddWarning(
+                            SqlValidationCodes.CartesianJoin,
+                            "Cartesian join may produce an unexpectedly large result.",
+                            join);
+                    }
+
+                    CheckJoinRelationships(join, left, right, scope);
+                }
+
+                return [.. left, .. right];
+            }
+            default:
+                return [];
+        }
+    }
+
+    private SourceBinding BindNamedTable(
+        NamedTable named,
+        IReadOnlyDictionary<string, Projection> ctes)
+    {
+        var fullName = JoinParts(named.Name.Parts);
+        var simpleName = named.Name.Parts[^1].Value;
+        if (ctes.TryGetValue(fullName, out var cte)
+            || named.Name.Parts.Count == 1
+            && ctes.TryGetValue(simpleName, out cte))
+        {
+            return SourceBinding.FromProjection(
+                named.Alias?.Value ?? simpleName,
+                cte,
+                fullName,
+                named.Alias is null ? [simpleName, fullName] : [named.Alias.Value]);
+        }
+
+        var table = _catalog.Resolve(named.Name);
+        if (table is null)
+        {
+            AddSchemaIssue(
+                SqlValidationCodes.UnknownTable,
+                $"Unknown table '{fullName}'.",
+                named.Name);
+            return SourceBinding.Unknown(
+                named.Alias?.Value ?? simpleName,
+                named.Alias is null ? [simpleName, fullName] : [named.Alias.Value]);
+        }
+
+        return SourceBinding.FromTable(
+            table,
+            named.Alias?.Value ?? simpleName,
+            named.Alias is null ? [simpleName, fullName] : [named.Alias.Value]);
+    }
+
+    private void ExpandStar(
+        StarExpression star,
+        Scope scope,
+        List<ProjectedColumn> projectedColumns)
+    {
+        if (star.Qualifier is null)
+        {
+            foreach (var source in scope.Sources)
+            {
+                projectedColumns.AddRange(source.ColumnOrder.Select(column =>
+                    new ProjectedColumn(column, source.Columns[column])));
+            }
+
+            return;
+        }
+
+        var qualifier = JoinParts(star.Qualifier);
+        var sourceBinding = scope.FindQualifier(qualifier);
+        if (sourceBinding is null)
+        {
+            AddSchemaIssue(
+                SqlValidationCodes.UnresolvedReference,
+                $"Unknown table or alias '{qualifier}'.",
+                star);
+            return;
+        }
+
+        projectedColumns.AddRange(sourceBinding.ColumnOrder.Select(column =>
+            new ProjectedColumn(column, sourceBinding.Columns[column])));
+    }
+
+    private void ValidateUsingColumn(
+        SqlIdentifier column,
+        IReadOnlyList<SourceBinding> left,
+        IReadOnlyList<SourceBinding> right)
+    {
+        var leftMatches = left.Count(source => source.Columns.ContainsKey(column.Value));
+        var rightMatches = right.Count(source => source.Columns.ContainsKey(column.Value));
+        if (leftMatches == 0 || rightMatches == 0)
+        {
+            AddSchemaIssue(
+                SqlValidationCodes.UnknownColumn,
+                $"JOIN USING column '{column.Value}' must exist on both sides of the join.",
+                column);
+        }
+    }
+
+    private SqlTypeFamily ValidateExpression(
+        SqlExpression expression,
+        Scope scope,
+        IReadOnlyDictionary<string, Projection> ctes)
+    {
+        switch (expression)
+        {
+            case ColumnExpression column:
+                return ResolveColumn(column, scope);
+            case StarExpression:
+                return SqlTypeFamily.Unknown;
+            case LiteralExpression literal:
+                return LiteralType(literal.Value);
+            case ParameterExpression parameter:
+                if (parameter.DefaultValue is not null)
+                {
+                    ValidateExpression(parameter.DefaultValue, scope, ctes);
+                }
+
+                return SqlTypeFamily.Unknown;
+            case ParenthesizedExpression parenthesized:
+                return ValidateExpression(parenthesized.Expression, scope, ctes);
+            case UnaryExpression unary:
+                return ValidateUnary(unary, scope, ctes);
+            case BinaryExpression binary:
+                return ValidateBinary(binary, scope, ctes);
+            case BetweenExpression between:
+                return ValidateBetween(between, scope, ctes);
+            case InExpression @in:
+                return ValidateIn(@in, scope, ctes);
+            case IsNullExpression isNull:
+                ValidateExpression(isNull.Expression, scope, ctes);
+                return SqlTypeFamily.Boolean;
+            case BooleanTestExpression booleanTest:
+                RequirePredicate(
+                    booleanTest.Expression,
+                    ValidateExpression(booleanTest.Expression, scope, ctes));
+                return SqlTypeFamily.Boolean;
+            case DistinctFromExpression distinct:
+            {
+                var left = ValidateExpression(distinct.Left, scope, ctes);
+                var right = ValidateExpression(distinct.Right, scope, ctes);
+                CheckComparison(distinct, left, right);
+                return SqlTypeFamily.Boolean;
+            }
+            case RowExpression row:
+                ValidateExpressions(row.Values, scope, ctes);
+                return SqlTypeFamily.Struct;
+            case DefaultExpression:
+                return SqlTypeFamily.Unknown;
+            case CollateExpression collate:
+                return ValidateExpression(collate.Expression, scope, ctes);
+            case ExtractExpression extract:
+                ValidateExpression(extract.Expression, scope, ctes);
+                return SqlTypeFamily.Numeric;
+            case IntervalExpression interval:
+                ValidateExpression(interval.Value, scope, ctes);
+                return SqlTypeFamily.Interval;
+            case SequenceValueExpression:
+                return SqlTypeFamily.Integer;
+            case FunctionCallExpression function:
+                return ValidateFunction(function, scope, ctes);
+            case WindowExpression window:
+                return ValidateWindow(window, scope, ctes);
+            case ExistsExpression exists:
+                ValidateQuery(exists.Query, ctes, scope);
+                return SqlTypeFamily.Boolean;
+            case SubqueryExpression subquery:
+            {
+                var projection = ValidateQuery(subquery.Query, ctes, scope);
+                if (projection.Columns.Count == 1) return projection.Columns[0].Type;
+                AddSchemaIssue(
+                    SqlValidationCodes.InvalidScalarSubquery,
+                    $"Scalar subquery projects {projection.Columns.Count} columns; expected one.",
+                    subquery);
+                return SqlTypeFamily.Unknown;
+            }
+            case CaseExpression @case:
+                return ValidateCase(@case, scope, ctes);
+            case CastExpression cast:
+                ValidateExpression(cast.Expression, scope, ctes);
+                return SqlTypeFamilies.Classify(cast.DataType.Name.Value);
+            case TryCastExpression cast:
+                ValidateExpression(cast.Expression, scope, ctes);
+                return SqlTypeFamilies.Classify(cast.DataType.Name.Value);
+            default:
+                return SqlTypeFamily.Unknown;
+        }
+    }
+
+    private SqlTypeFamily ResolveColumn(ColumnExpression column, Scope scope)
+    {
+        var name = column.Parts[^1].Value;
+        if (column.Parts.Count > 1)
+        {
+            var qualifier = JoinParts(column.Parts.Take(column.Parts.Count - 1));
+            var source = scope.FindQualifier(qualifier);
+            if (source is null)
+            {
+                AddSchemaIssue(
+                    SqlValidationCodes.UnresolvedReference,
+                    $"Unknown table or alias '{qualifier}' in column reference '{JoinParts(column.Parts)}'.",
+                    column);
+                return SqlTypeFamily.Unknown;
+            }
+
+            if (source.Columns.TryGetValue(name, out var qualifiedType)) return qualifiedType;
+            if (!source.IsUnknown)
+            {
+                AddSchemaIssue(
+                    SqlValidationCodes.UnknownColumn,
+                    $"Unknown column '{name}' on '{qualifier}'.",
+                    column);
+            }
+
+            return SqlTypeFamily.Unknown;
+        }
+
+        var matches = scope.FindColumn(name);
+        if (matches.Count == 0 && scope.Sources.Count == 0 && scope.Parent is null)
+        {
+            matches = _catalog.FindColumn(name)
+                .Select(static match => new ColumnMatch(
+                    SourceBinding.FromTable(match.Table, match.Table.SimpleName, [match.Table.SimpleName]),
+                    match.Type))
+                .ToArray();
+        }
+
+        if (matches.Count == 0)
+        {
+            if (!scope.HasUnknownSource)
+            {
+                AddSchemaIssue(
+                    SqlValidationCodes.UnknownColumn,
+                    $"Unknown column '{name}'.",
+                    column);
+            }
+
+            return SqlTypeFamily.Unknown;
+        }
+
+        if (matches.Count > 1 && _options.CheckReferences)
+        {
+            AddSchemaIssue(
+                SqlValidationCodes.AmbiguousColumnReference,
+                $"Column reference '{name}' is ambiguous.",
+                column);
+        }
+
+        return matches[0].Type;
+    }
+
+    private SqlTypeFamily ValidateUnary(
+        UnaryExpression unary,
+        Scope scope,
+        IReadOnlyDictionary<string, Projection> ctes)
+    {
+        var operand = ValidateExpression(unary.Operand, scope, ctes);
+        if (!_options.CheckTypes) return operand;
+
+        if (unary.Operator == UnaryOperator.Not)
+        {
+            RequirePredicate(unary.Operand, operand);
+            return SqlTypeFamily.Boolean;
+        }
+
+        if (unary.Operator is UnaryOperator.Plus or UnaryOperator.Minus
+            && !IsNumericOrUnknown(operand))
+        {
+            AddTypeIssue(
+                SqlValidationCodes.InvalidArithmeticType,
+                SqlValidationCodes.ImplicitArithmeticCast,
+                $"Unary {unary.Operator} requires a numeric operand, not {TypeName(operand)}.",
+                unary);
+        }
+
+        return operand;
+    }
+
+    private SqlTypeFamily ValidateBinary(
+        BinaryExpression binary,
+        Scope scope,
+        IReadOnlyDictionary<string, Projection> ctes)
+    {
+        var left = ValidateExpression(binary.Left, scope, ctes);
+        var right = ValidateExpression(binary.Right, scope, ctes);
+
+        if (binary.Operator is BinaryOperator.And or BinaryOperator.Or)
+        {
+            RequirePredicate(binary.Left, left);
+            RequirePredicate(binary.Right, right);
+            return SqlTypeFamily.Boolean;
+        }
+
+        if (binary.Operator is BinaryOperator.Equal
+            or BinaryOperator.NotEqual
+            or BinaryOperator.GreaterThan
+            or BinaryOperator.GreaterThanOrEqual
+            or BinaryOperator.LessThan
+            or BinaryOperator.LessThanOrEqual
+            or BinaryOperator.Like
+            or BinaryOperator.NotLike
+            or BinaryOperator.ILike
+            or BinaryOperator.NotILike)
+        {
+            CheckComparison(binary, left, right);
+            return SqlTypeFamily.Boolean;
+        }
+
+        if (!_options.CheckTypes) return CommonType(left, right);
+        if (binary.Operator == BinaryOperator.Concatenate)
+        {
+            if (!IsStringOrBinaryOrUnknown(left) || !IsStringOrBinaryOrUnknown(right))
+            {
+                AddTypeIssue(
+                    SqlValidationCodes.InvalidArithmeticType,
+                    SqlValidationCodes.ImplicitArithmeticCast,
+                    $"Concatenation requires string or binary operands, not {TypeName(left)} and {TypeName(right)}.",
+                    binary);
+            }
+
+            return left == SqlTypeFamily.Binary && right == SqlTypeFamily.Binary
+                ? SqlTypeFamily.Binary
+                : SqlTypeFamily.String;
+        }
+
+        if (binary.Operator is BinaryOperator.Add or BinaryOperator.Subtract)
+        {
+            if (left == SqlTypeFamily.Interval && right == SqlTypeFamily.Interval)
+            {
+                return SqlTypeFamily.Interval;
+            }
+
+            if (IsTemporal(left) && right == SqlTypeFamily.Interval) return left;
+            if (binary.Operator == BinaryOperator.Add
+                && left == SqlTypeFamily.Interval
+                && IsTemporal(right))
+            {
+                return right;
+            }
+
+            if (binary.Operator == BinaryOperator.Subtract
+                && IsTemporal(left)
+                && IsTemporal(right))
+            {
+                return SqlTypeFamily.Interval;
+            }
+        }
+
+        if (!IsNumericOrUnknown(left) || !IsNumericOrUnknown(right))
+        {
+            AddTypeIssue(
+                SqlValidationCodes.InvalidArithmeticType,
+                SqlValidationCodes.ImplicitArithmeticCast,
+                $"Arithmetic requires numeric operands, not {TypeName(left)} and {TypeName(right)}.",
+                binary);
+        }
+
+        return CommonType(left, right);
+    }
+
+    private SqlTypeFamily ValidateBetween(
+        BetweenExpression between,
+        Scope scope,
+        IReadOnlyDictionary<string, Projection> ctes)
+    {
+        var value = ValidateExpression(between.Expression, scope, ctes);
+        var lower = ValidateExpression(between.Lower, scope, ctes);
+        var upper = ValidateExpression(between.Upper, scope, ctes);
+        CheckComparison(between, value, lower);
+        CheckComparison(between, value, upper);
+        return SqlTypeFamily.Boolean;
+    }
+
+    private SqlTypeFamily ValidateIn(
+        InExpression @in,
+        Scope scope,
+        IReadOnlyDictionary<string, Projection> ctes)
+    {
+        var valueType = ValidateExpression(@in.Expression, scope, ctes);
+        foreach (var value in @in.Values)
+        {
+            CheckComparison(@in, valueType, ValidateExpression(value, scope, ctes));
+        }
+
+        if (@in.Query is not null)
+        {
+            var projection = ValidateQuery(@in.Query, ctes, scope);
+            if (projection.Columns.Count == 1)
+            {
+                CheckComparison(@in, valueType, projection.Columns[0].Type);
+            }
+            else if (_options.CheckTypes)
+            {
+                AddTypeIssue(
+                    SqlValidationCodes.SetOperationArityMismatch,
+                    SqlValidationCodes.SetOperationImplicitCoercion,
+                    $"IN subquery projects {projection.Columns.Count} columns; expected one.",
+                    @in);
+            }
+        }
+
+        return SqlTypeFamily.Boolean;
+    }
+
+    private SqlTypeFamily ValidateFunction(
+        FunctionCallExpression function,
+        Scope scope,
+        IReadOnlyDictionary<string, Projection> ctes)
+    {
+        var argumentTypes = function.Arguments
+            .Select(argument => ValidateExpression(argument, scope, ctes))
+            .ToArray();
+        if (function.Filter is not null)
+        {
+            RequirePredicate(
+                function.Filter,
+                ValidateExpression(function.Filter, scope, ctes));
+        }
+
+        if (function.WithinGroup is not null)
+        {
+            ValidateOrderBy(function.WithinGroup, scope, ctes, null);
+        }
+
+        var name = function.Name.Value.ToUpperInvariant();
+        return name switch
+        {
+            "COUNT" => SqlTypeFamily.Integer,
+            "SUM" or "AVG" => ValidateFunctionArguments(
+                function,
+                argumentTypes,
+                1,
+                static type => IsNumericOrUnknown(type),
+                SqlTypeFamily.Numeric),
+            "MIN" or "MAX" => ValidateFunctionArguments(
+                function,
+                argumentTypes,
+                1,
+                static _ => true,
+                argumentTypes.FirstOrDefault()),
+            "ABS" => ValidateFunctionArguments(
+                function,
+                argumentTypes,
+                1,
+                static type => IsNumericOrUnknown(type),
+                argumentTypes.FirstOrDefault()),
+            "LOWER" or "UPPER" or "TRIM" or "LTRIM" or "RTRIM" => ValidateFunctionArguments(
+                function,
+                argumentTypes,
+                1,
+                static type => IsStringOrUnknown(type),
+                SqlTypeFamily.String),
+            "LENGTH" or "CHAR_LENGTH" => ValidateFunctionArguments(
+                function,
+                argumentTypes,
+                1,
+                static type => IsStringOrBinaryOrUnknown(type),
+                SqlTypeFamily.Integer),
+            "COALESCE" => ValidateCoalesce(function, argumentTypes),
+            _ => SqlTypeFamily.Unknown,
+        };
+    }
+
+    private SqlTypeFamily ValidateFunctionArguments(
+        FunctionCallExpression function,
+        IReadOnlyList<SqlTypeFamily> arguments,
+        int expectedArity,
+        Func<SqlTypeFamily, bool> accepts,
+        SqlTypeFamily result)
+    {
+        if (!_options.CheckTypes) return result;
+        if (arguments.Count != expectedArity)
+        {
+            AddTypeIssue(
+                SqlValidationCodes.InvalidFunctionArity,
+                SqlValidationCodes.FunctionArgumentCoercion,
+                $"Function {function.Name.Value} expects {expectedArity} argument(s), not {arguments.Count}.",
+                function);
+            return result;
+        }
+
+        if (!accepts(arguments[0]))
+        {
+            AddTypeIssue(
+                SqlValidationCodes.InvalidFunctionArgumentType,
+                SqlValidationCodes.FunctionArgumentCoercion,
+                $"Function {function.Name.Value} does not accept a {TypeName(arguments[0])} argument.",
+                function.Arguments[0]);
+        }
+
+        return result;
+    }
+
+    private SqlTypeFamily ValidateCoalesce(
+        FunctionCallExpression function,
+        IReadOnlyList<SqlTypeFamily> arguments)
+    {
+        if (_options.CheckTypes && arguments.Count == 0)
+        {
+            AddTypeIssue(
+                SqlValidationCodes.InvalidFunctionArity,
+                SqlValidationCodes.FunctionArgumentCoercion,
+                "Function COALESCE expects at least one argument.",
+                function);
+            return SqlTypeFamily.Unknown;
+        }
+
+        var result = arguments.FirstOrDefault(static type => type != SqlTypeFamily.Unknown);
+        if (_options.CheckTypes)
+        {
+            foreach (var argument in arguments)
+            {
+                if (!TypesCompatible(result, argument))
+                {
+                    AddTypeIssue(
+                        SqlValidationCodes.InvalidFunctionArgumentType,
+                        SqlValidationCodes.FunctionArgumentCoercion,
+                        $"COALESCE arguments have incompatible {TypeName(result)} and {TypeName(argument)} types.",
+                        function);
+                    break;
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private SqlTypeFamily ValidateWindow(
+        WindowExpression window,
+        Scope scope,
+        IReadOnlyDictionary<string, Projection> ctes)
+    {
+        var result = ValidateExpression(window.Expression, scope, ctes);
+        ValidateExpressions(window.PartitionBy, scope, ctes);
+        ValidateOrderBy(window.OrderBy, scope, ctes, null);
+        if (window.Frame is not null)
+        {
+            ValidateExpressionIfPresent(window.Frame.Start.Offset, scope, ctes);
+            ValidateExpressionIfPresent(window.Frame.End?.Offset, scope, ctes);
+        }
+
+        return result;
+    }
+
+    private SqlTypeFamily ValidateCase(
+        CaseExpression @case,
+        Scope scope,
+        IReadOnlyDictionary<string, Projection> ctes)
+    {
+        var operandType = @case.Operand is null
+            ? SqlTypeFamily.Unknown
+            : ValidateExpression(@case.Operand, scope, ctes);
+        var result = SqlTypeFamily.Unknown;
+        foreach (var when in @case.Whens)
+        {
+            var condition = ValidateExpression(when.Condition, scope, ctes);
+            if (@case.Operand is null)
+            {
+                RequirePredicate(when.Condition, condition);
+            }
+            else
+            {
+                CheckComparison(when.Condition, operandType, condition);
+            }
+
+            result = CommonType(result, ValidateExpression(when.Result, scope, ctes));
+        }
+
+        if (@case.Else is not null)
+        {
+            result = CommonType(result, ValidateExpression(@case.Else, scope, ctes));
+        }
+
+        return result;
+    }
+
+    private void CheckComparison(SqlNode node, SqlTypeFamily left, SqlTypeFamily right)
+    {
+        if (!_options.CheckTypes || TypesCompatible(left, right)) return;
+        AddTypeIssue(
+            SqlValidationCodes.IncompatibleComparisonTypes,
+            SqlValidationCodes.ImplicitComparisonCast,
+            $"Comparison has incompatible {TypeName(left)} and {TypeName(right)} operands.",
+            node);
+    }
+
+    private void RequirePredicate(SqlNode node, SqlTypeFamily type)
+    {
+        if (!_options.CheckTypes
+            || type is SqlTypeFamily.Boolean or SqlTypeFamily.Unknown)
+        {
+            return;
+        }
+
+        AddTypeIssue(
+            SqlValidationCodes.InvalidPredicateType,
+            SqlValidationCodes.PredicateTypeConcern,
+            $"Predicate expression has type {TypeName(type)} instead of boolean.",
+            node);
+    }
+
+    private void ValidateInsert(
+        InsertStatement insert,
+        IReadOnlyDictionary<string, Projection> ctes)
+    {
+        var target = ResolveTable(insert.Target);
+        if (target is null) return;
+
+        var targetColumns = ResolveInsertColumns(insert, target);
+        var scope = new Scope(null);
+        if (insert.Values is not null)
+        {
+            foreach (var row in insert.Values)
+            {
+                if (_options.CheckTypes && row.Count != targetColumns.Count)
+                {
+                    AddTypeIssue(
+                        SqlValidationCodes.InvalidAssignmentType,
+                        SqlValidationCodes.ImplicitAssignmentCast,
+                        $"INSERT row has {row.Count} values for {targetColumns.Count} target columns.",
+                        insert);
+                }
+
+                for (var i = 0; i < row.Count; i++)
+                {
+                    var valueType = ValidateExpression(row[i], scope, ctes);
+                    if (i < targetColumns.Count)
+                    {
+                        CheckAssignment(targetColumns[i], valueType, row[i]);
+                    }
+                }
+            }
+        }
+
+        if (insert.Source is not null)
+        {
+            var source = ValidateQuery(insert.Source, ctes, null);
+            if (_options.CheckTypes && source.Columns.Count != targetColumns.Count)
+            {
+                AddTypeIssue(
+                    SqlValidationCodes.InvalidAssignmentType,
+                    SqlValidationCodes.ImplicitAssignmentCast,
+                    $"INSERT source projects {source.Columns.Count} values for {targetColumns.Count} target columns.",
+                    insert.Source);
+            }
+
+            for (var i = 0; i < source.Columns.Count && i < targetColumns.Count; i++)
+            {
+                CheckAssignment(targetColumns[i], source.Columns[i].Type, insert.Source);
+            }
+        }
+
+        var returningScope = new Scope(null);
+        returningScope.Add(SourceBinding.FromTable(target, target.SimpleName, [target.SimpleName]));
+        ValidateExpressions(insert.Returning, returningScope, ctes);
+        ValidateExpressions(insert.ReturningInto, returningScope, ctes);
+    }
+
+    private IReadOnlyList<ColumnInfo> ResolveInsertColumns(
+        InsertStatement insert,
+        TableInfo target) =>
+        ResolveColumns(target, insert.Columns, insert);
+
+    private IReadOnlyList<ColumnInfo> ResolveColumns(
+        TableInfo target,
+        IReadOnlyList<SqlIdentifier>? identifiers,
+        SqlNode node)
+    {
+        if (identifiers is null) return target.ColumnOrder
+            .Select(column => target.Columns[column])
+            .ToArray();
+
+        var columns = new List<ColumnInfo>();
+        foreach (var identifier in identifiers)
+        {
+            if (target.Columns.TryGetValue(identifier.Value, out var column))
+            {
+                columns.Add(column);
+            }
+            else
+            {
+                AddSchemaIssue(
+                    SqlValidationCodes.UnknownColumn,
+                    $"Unknown target column '{identifier.Value}' on '{target.DisplayName}'.",
+                    identifier.Span.IsEmpty ? node : identifier);
+            }
+        }
+
+        return columns;
+    }
+
+    private void ValidateUpdate(
+        UpdateStatement update,
+        IReadOnlyDictionary<string, Projection> ctes)
+    {
+        var target = ResolveTable(update.Target.Name);
+        var scope = new Scope(null);
+        if (target is not null)
+        {
+            scope.Add(SourceBinding.FromTable(
+                target,
+                update.Target.Alias?.Value ?? target.SimpleName,
+                update.Target.Alias is null
+                    ? [target.SimpleName, target.DisplayName]
+                    : [update.Target.Alias.Value]));
+        }
+
+        if (update.From is not null) BindTableSource(update.From, scope, ctes);
+        foreach (var assignment in update.Assignments)
+        {
+            var valueType = ValidateExpression(assignment.Value, scope, ctes);
+            if (target is null) continue;
+
+            var targetName = assignment.Column.Parts[^1].Value;
+            if (target.Columns.TryGetValue(targetName, out var targetColumn))
+            {
+                CheckAssignment(targetColumn, valueType, assignment);
+            }
+            else
+            {
+                AddSchemaIssue(
+                    SqlValidationCodes.UnknownColumn,
+                    $"Unknown target column '{targetName}' on '{target.DisplayName}'.",
+                    assignment.Column);
+            }
+        }
+
+        if (update.Where is not null)
+        {
+            RequirePredicate(update.Where, ValidateExpression(update.Where, scope, ctes));
+        }
+
+        ValidateExpressions(update.Returning, scope, ctes);
+        ValidateExpressions(update.ReturningInto, scope, ctes);
+    }
+
+    private void ValidateDelete(
+        DeleteStatement delete,
+        IReadOnlyDictionary<string, Projection> ctes)
+    {
+        var target = ResolveTable(delete.Target.Name);
+        var scope = new Scope(null);
+        if (target is not null)
+        {
+            scope.Add(SourceBinding.FromTable(
+                target,
+                delete.Target.Alias?.Value ?? target.SimpleName,
+                delete.Target.Alias is null
+                    ? [target.SimpleName, target.DisplayName]
+                    : [delete.Target.Alias.Value]));
+        }
+
+        if (delete.Using is not null) BindTableSource(delete.Using, scope, ctes);
+        if (delete.Where is not null)
+        {
+            RequirePredicate(delete.Where, ValidateExpression(delete.Where, scope, ctes));
+        }
+
+        ValidateExpressions(delete.Returning, scope, ctes);
+        ValidateExpressions(delete.ReturningInto, scope, ctes);
+    }
+
+    private void ValidateMerge(
+        MergeStatement merge,
+        IReadOnlyDictionary<string, Projection> ctes)
+    {
+        var scope = new Scope(null);
+        var target = ResolveTable(merge.Target.Name);
+        if (target is not null)
+        {
+            scope.Add(SourceBinding.FromTable(
+                target,
+                merge.Target.Alias?.Value ?? target.SimpleName,
+                merge.Target.Alias is null
+                    ? [target.SimpleName, target.DisplayName]
+                    : [merge.Target.Alias.Value]));
+        }
+
+        BindTableSource(merge.Source, scope, ctes);
+        RequirePredicate(merge.Condition, ValidateExpression(merge.Condition, scope, ctes));
+        foreach (var when in merge.WhenClauses)
+        {
+            if (when.Condition is not null)
+            {
+                RequirePredicate(
+                    when.Condition,
+                    ValidateExpression(when.Condition, scope, ctes));
+            }
+
+            if (when.Action is MergeUpdateAction update)
+            {
+                foreach (var assignment in update.Assignments)
+                {
+                    var valueType = ValidateExpression(assignment.Value, scope, ctes);
+                    if (target is null) continue;
+
+                    var targetName = assignment.Column.Parts[^1].Value;
+                    if (target.Columns.TryGetValue(targetName, out var targetColumn))
+                    {
+                        CheckAssignment(targetColumn, valueType, assignment);
+                    }
+                    else
+                    {
+                        AddSchemaIssue(
+                            SqlValidationCodes.UnknownColumn,
+                            $"Unknown target column '{targetName}' on '{target.DisplayName}'.",
+                            assignment.Column);
+                    }
+                }
+            }
+            else if (when.Action is MergeInsertAction insert)
+            {
+                if (target is null)
+                {
+                    ValidateExpressions(insert.Values, scope, ctes);
+                    continue;
+                }
+
+                var targetColumns = ResolveColumns(
+                    target,
+                    insert.Columns,
+                    insert);
+                if (_options.CheckTypes && insert.Values.Count != targetColumns.Count)
+                {
+                    AddTypeIssue(
+                        SqlValidationCodes.InvalidAssignmentType,
+                        SqlValidationCodes.ImplicitAssignmentCast,
+                        $"MERGE INSERT has {insert.Values.Count} values for {targetColumns.Count} target columns.",
+                        insert);
+                }
+
+                for (var i = 0; i < insert.Values.Count; i++)
+                {
+                    var valueType = ValidateExpression(insert.Values[i], scope, ctes);
+                    if (i < targetColumns.Count)
+                    {
+                        CheckAssignment(targetColumns[i], valueType, insert.Values[i]);
+                    }
+                }
+            }
+        }
+
+        ValidateExpressions(merge.Returning, scope, ctes);
+        ValidateExpressions(merge.ReturningInto, scope, ctes);
+    }
+
+    private TableInfo? ResolveTable(TableName name)
+    {
+        var table = _catalog.Resolve(name);
+        if (table is null)
+        {
+            AddSchemaIssue(
+                SqlValidationCodes.UnknownTable,
+                $"Unknown table '{JoinParts(name.Parts)}'.",
+                name);
+        }
+
+        return table;
+    }
+
+    private void CheckAssignment(ColumnInfo target, SqlTypeFamily source, SqlNode node)
+    {
+        if (!_options.CheckTypes || TypesCompatible(target.Type, source)) return;
+        AddTypeIssue(
+            SqlValidationCodes.InvalidAssignmentType,
+            SqlValidationCodes.ImplicitAssignmentCast,
+            $"Cannot assign {TypeName(source)} to {TypeName(target.Type)} column '{target.Name}'.",
+            node);
+    }
+
+    private void ValidateForeignKeys()
+    {
+        foreach (var table in _catalog.Tables)
+        {
+            foreach (var column in table.Model.Columns)
+            {
+                if (column.References is null) continue;
+                ValidateForeignKey(
+                    table,
+                    [column.Name],
+                    column.References.Table,
+                    column.References.Schema,
+                    [column.References.Column],
+                    column.Name);
+            }
+
+            if (table.Model.ForeignKeys is null) continue;
+            foreach (var foreignKey in table.Model.ForeignKeys)
+            {
+                ValidateForeignKey(
+                    table,
+                    foreignKey.Columns,
+                    foreignKey.References.Table,
+                    foreignKey.References.Schema,
+                    foreignKey.References.Columns,
+                    foreignKey.Name ?? "<unnamed>");
+            }
+        }
+    }
+
+    private void ValidateForeignKey(
+        TableInfo source,
+        IReadOnlyList<string> sourceColumns,
+        string targetTable,
+        string? targetSchema,
+        IReadOnlyList<string> targetColumns,
+        string name)
+    {
+        if (sourceColumns.Count == 0
+            || sourceColumns.Count != targetColumns.Count)
+        {
+            AddReferenceIssue(
+                $"Foreign key '{name}' on '{source.DisplayName}' has mismatched source and target column counts.");
+            return;
+        }
+
+        var target = _catalog.Resolve(targetTable, targetSchema);
+        if (target is null)
+        {
+            AddReferenceIssue(
+                $"Foreign key '{name}' on '{source.DisplayName}' references unknown table '{targetTable}'.");
+            return;
+        }
+
+        for (var i = 0; i < sourceColumns.Count; i++)
+        {
+            if (!source.Columns.TryGetValue(sourceColumns[i], out var sourceColumn))
+            {
+                AddReferenceIssue(
+                    $"Foreign key '{name}' references unknown source column '{source.DisplayName}.{sourceColumns[i]}'.");
+                continue;
+            }
+
+            if (!target.Columns.TryGetValue(targetColumns[i], out var targetColumn))
+            {
+                AddReferenceIssue(
+                    $"Foreign key '{name}' references unknown target column '{target.DisplayName}.{targetColumns[i]}'.");
+                continue;
+            }
+
+            if (!TypesCompatible(sourceColumn.Type, targetColumn.Type))
+            {
+                AddReferenceIssue(
+                    $"Foreign key '{name}' has incompatible {TypeName(sourceColumn.Type)} and {TypeName(targetColumn.Type)} column types.");
+            }
+
+        }
+
+        if (!target.IsUniqueKey(targetColumns))
+        {
+            AddWarning(
+                SqlValidationCodes.WeakReferenceIntegrity,
+                $"Referenced columns on '{target.DisplayName}' are not marked as a primary or unique key.",
+                null);
+        }
+    }
+
+    private void CheckJoinRelationships(
+        JoinTable join,
+        IReadOnlyList<SourceBinding> left,
+        IReadOnlyList<SourceBinding> right,
+        Scope scope)
+    {
+        var relationships = _catalog.Relationships
+            .Where(relationship =>
+                ContainsTable(left, relationship.Source)
+                && ContainsTable(right, relationship.Target)
+                || ContainsTable(left, relationship.Target)
+                && ContainsTable(right, relationship.Source))
+            .ToArray();
+        if (relationships.Length == 0 || join.Kind == JoinKind.Cross) return;
+
+        var pairs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (join.Condition is not null)
+        {
+            CollectEqualityPairs(join.Condition, scope, pairs);
+        }
+
+        if (join.Using is not null)
+        {
+            foreach (var column in join.Using)
+            {
+                foreach (var leftSource in left.Where(source =>
+                    source.Table is not null && source.Columns.ContainsKey(column.Value)))
+                {
+                    foreach (var rightSource in right.Where(source =>
+                        source.Table is not null && source.Columns.ContainsKey(column.Value)))
+                    {
+                        pairs.Add(PairKey(
+                            leftSource.Table!,
+                            column.Value,
+                            rightSource.Table!,
+                            column.Value));
+                    }
+                }
+            }
+        }
+
+        var usesRelationship = relationships.Any(relationship =>
+            relationship.SourceColumns
+                .Zip(relationship.TargetColumns)
+                .All(columns => pairs.Contains(PairKey(
+                    relationship.Source,
+                    columns.First,
+                    relationship.Target,
+                    columns.Second))));
+        if (!usesRelationship)
+        {
+            AddWarning(
+                SqlValidationCodes.JoinNotUsingDeclaredReference,
+                "Join condition does not use the declared relationship between these tables.",
+                join);
+        }
+    }
+
+    private static bool ContainsTable(
+        IReadOnlyList<SourceBinding> bindings,
+        TableInfo table) =>
+        bindings.Any(binding => ReferenceEquals(binding.Table, table));
+
+    private void CollectEqualityPairs(
+        SqlExpression expression,
+        Scope scope,
+        HashSet<string> pairs)
+    {
+        if (expression is BinaryExpression { Operator: BinaryOperator.And } and)
+        {
+            CollectEqualityPairs(and.Left, scope, pairs);
+            CollectEqualityPairs(and.Right, scope, pairs);
+            return;
+        }
+
+        if (expression is not BinaryExpression
+            {
+                Operator: BinaryOperator.Equal,
+                Left: ColumnExpression left,
+                Right: ColumnExpression right,
+            })
+        {
+            return;
+        }
+
+        if (TryResolveColumnQuiet(left, scope, out var leftSource, out var leftName)
+            && TryResolveColumnQuiet(right, scope, out var rightSource, out var rightName)
+            && leftSource.Table is not null
+            && rightSource.Table is not null)
+        {
+            pairs.Add(PairKey(leftSource.Table, leftName, rightSource.Table, rightName));
+        }
+    }
+
+    private static bool TryResolveColumnQuiet(
+        ColumnExpression column,
+        Scope scope,
+        out SourceBinding source,
+        out string name)
+    {
+        name = column.Parts[^1].Value;
+        if (column.Parts.Count > 1)
+        {
+            var qualifier = JoinParts(column.Parts.Take(column.Parts.Count - 1));
+            source = scope.FindQualifier(qualifier)!;
+            return source is not null && source.Columns.ContainsKey(name);
+        }
+
+        var matches = scope.FindColumn(name);
+        if (matches.Count == 1)
+        {
+            source = matches[0].Source;
+            return true;
+        }
+
+        source = null!;
+        return false;
+    }
+
+    private static string PairKey(
+        TableInfo firstTable,
+        string firstColumn,
+        TableInfo secondTable,
+        string secondColumn)
+    {
+        var first = $"{firstTable.Key}.{firstColumn}";
+        var second = $"{secondTable.Key}.{secondColumn}";
+        return string.Compare(first, second, StringComparison.OrdinalIgnoreCase) <= 0
+            ? $"{first}={second}"
+            : $"{second}={first}";
+    }
+
+    private void ValidateOrderBy(
+        IReadOnlyList<OrderByItem>? orderBy,
+        Scope scope,
+        IReadOnlyDictionary<string, Projection> ctes,
+        IReadOnlyDictionary<string, SqlTypeFamily>? aliases)
+    {
+        if (orderBy is null) return;
+        foreach (var item in orderBy)
+        {
+            if (aliases is null || !TryGetAliasType(item.Expression, aliases, out _))
+            {
+                ValidateExpression(item.Expression, scope, ctes);
+            }
+        }
+    }
+
+    private static bool TryGetAliasType(
+        SqlExpression expression,
+        IReadOnlyDictionary<string, SqlTypeFamily> aliases,
+        out SqlTypeFamily type)
+    {
+        if (expression is ColumnExpression { Parts.Count: 1 } column
+            && aliases.TryGetValue(column.Parts[0].Value, out type))
+        {
+            return true;
+        }
+
+        type = SqlTypeFamily.Unknown;
+        return false;
+    }
+
+    private static IReadOnlyDictionary<string, SqlTypeFamily> BuildAliasMap(
+        IReadOnlyList<ProjectedColumn> columns)
+    {
+        var aliases = new Dictionary<string, SqlTypeFamily>(StringComparer.OrdinalIgnoreCase);
+        foreach (var column in columns)
+        {
+            if (column.Name is not null) aliases.TryAdd(column.Name, column.Type);
+        }
+
+        return aliases;
+    }
+
+    private void ValidateExpressions(
+        IEnumerable<SqlExpression>? expressions,
+        Scope scope,
+        IReadOnlyDictionary<string, Projection> ctes)
+    {
+        if (expressions is null) return;
+        foreach (var expression in expressions)
+        {
+            ValidateExpression(expression, scope, ctes);
+        }
+    }
+
+    private void ValidateExpressionIfPresent(
+        SqlExpression? expression,
+        Scope scope,
+        IReadOnlyDictionary<string, Projection> ctes)
+    {
+        if (expression is not null) ValidateExpression(expression, scope, ctes);
+    }
+
+    private void AddSchemaIssue(string code, string message, SqlNode? node)
+    {
+        _diagnostics.Add(new SqlValidationDiagnostic(
+            _options.Strict
+                ? SqlValidationSeverity.Error
+                : SqlValidationSeverity.Warning,
+            code,
+            message,
+            node is null ? null : SqlValidator.CreateLocation(_sql, node)));
+    }
+
+    private void AddTypeIssue(
+        string errorCode,
+        string warningCode,
+        string message,
+        SqlNode node)
+    {
+        if (!_options.CheckTypes) return;
+        _diagnostics.Add(new SqlValidationDiagnostic(
+            _options.Strict
+                ? SqlValidationSeverity.Error
+                : SqlValidationSeverity.Warning,
+            _options.Strict ? errorCode : warningCode,
+            message,
+            SqlValidator.CreateLocation(_sql, node)));
+    }
+
+    private void AddReferenceIssue(string message)
+    {
+        _diagnostics.Add(new SqlValidationDiagnostic(
+            _options.Strict
+                ? SqlValidationSeverity.Error
+                : SqlValidationSeverity.Warning,
+            _options.Strict
+                ? SqlValidationCodes.InvalidForeignKeyReference
+                : SqlValidationCodes.WeakReferenceIntegrity,
+            message));
+    }
+
+    private void AddWarning(string code, string message, SqlNode? node)
+    {
+        _diagnostics.Add(new SqlValidationDiagnostic(
+            SqlValidationSeverity.Warning,
+            code,
+            message,
+            node is null ? null : SqlValidator.CreateLocation(_sql, node)));
+    }
+
+    private static string? InferProjectionName(SqlExpression expression, int index) =>
+        expression switch
+        {
+            ColumnExpression column => column.Parts[^1].Value,
+            FunctionCallExpression function => function.Name.Value,
+            _ => $"column{index + 1}",
+        };
+
+    private static Projection InferRecursiveProjection(SqlQuery query)
+    {
+        var columns = query switch
+        {
+            SelectStatement select => select.Projections
+                .Select((projection, index) => new ProjectedColumn(
+                    projection.Alias?.Value
+                        ?? InferProjectionName(projection.Expression, index),
+                    SqlTypeFamily.Unknown))
+                .ToArray(),
+            ValuesStatement values when values.Rows.Count > 0 => values.Rows[0]
+                .Select((_, index) =>
+                    new ProjectedColumn($"column{index + 1}", SqlTypeFamily.Unknown))
+                .ToArray(),
+            SetOperationStatement set => InferRecursiveProjection(set.Left).Columns,
+            _ => Array.Empty<ProjectedColumn>(),
+        };
+        return new Projection(columns);
+    }
+
+    private static string JoinParts(IEnumerable<SqlIdentifier> parts) =>
+        string.Join('.', parts.Select(static part => part.Value));
+
+    private static SqlTypeFamily LiteralType(object? value) => value switch
+    {
+        null => SqlTypeFamily.Unknown,
+        bool => SqlTypeFamily.Boolean,
+        sbyte or byte or short or ushort or int or uint or long or ulong =>
+            SqlTypeFamily.Integer,
+        float or double or decimal => SqlTypeFamily.Numeric,
+        string or char => SqlTypeFamily.String,
+        byte[] => SqlTypeFamily.Binary,
+        DateTime or DateTimeOffset => SqlTypeFamily.Timestamp,
+        DateOnly => SqlTypeFamily.Date,
+        TimeOnly or TimeSpan => SqlTypeFamily.Time,
+        Guid => SqlTypeFamily.Uuid,
+        _ => SqlTypeFamily.Unknown,
+    };
+
+    private static bool TypesCompatible(SqlTypeFamily left, SqlTypeFamily right)
+    {
+        if (left == SqlTypeFamily.Unknown || right == SqlTypeFamily.Unknown) return true;
+        if (left == right) return true;
+        if (IsNumeric(left) && IsNumeric(right)) return true;
+        if (IsTemporal(left) && IsTemporal(right)) return true;
+        return false;
+    }
+
+    private static SqlTypeFamily CommonType(SqlTypeFamily left, SqlTypeFamily right)
+    {
+        if (left == SqlTypeFamily.Unknown) return right;
+        if (right == SqlTypeFamily.Unknown) return left;
+        if (left == right) return left;
+        if (IsNumeric(left) && IsNumeric(right)) return SqlTypeFamily.Numeric;
+        if (IsTemporal(left) && IsTemporal(right)) return SqlTypeFamily.Timestamp;
+        return SqlTypeFamily.Unknown;
+    }
+
+    private static bool IsNumeric(SqlTypeFamily type) =>
+        type is SqlTypeFamily.Integer or SqlTypeFamily.Numeric;
+
+    private static bool IsTemporal(SqlTypeFamily type) =>
+        type is SqlTypeFamily.Date
+            or SqlTypeFamily.Time
+            or SqlTypeFamily.Timestamp;
+
+    private static bool IsNumericOrUnknown(SqlTypeFamily type) =>
+        type == SqlTypeFamily.Unknown || IsNumeric(type);
+
+    private static bool IsStringOrUnknown(SqlTypeFamily type) =>
+        type is SqlTypeFamily.Unknown or SqlTypeFamily.String;
+
+    private static bool IsStringOrBinaryOrUnknown(SqlTypeFamily type) =>
+        type is SqlTypeFamily.Unknown or SqlTypeFamily.String or SqlTypeFamily.Binary;
+
+    private static string TypeName(SqlTypeFamily type) => type.ToString().ToLowerInvariant();
+
+    private sealed record ProjectedColumn(string? Name, SqlTypeFamily Type);
+
+    private sealed record Projection(IReadOnlyList<ProjectedColumn> Columns)
+    {
+        public static Projection Empty { get; } = new(Array.Empty<ProjectedColumn>());
+    }
+
+    private sealed record ColumnMatch(SourceBinding Source, SqlTypeFamily Type);
+
+    private sealed class Scope(Scope? parent)
+    {
+        private readonly Dictionary<string, SourceBinding> _qualifiers =
+            new(StringComparer.OrdinalIgnoreCase);
+
+        public Scope? Parent { get; } = parent;
+
+        public List<SourceBinding> Sources { get; } = [];
+
+        public bool HasUnknownSource =>
+            Sources.Any(static source => source.IsUnknown)
+            || Parent?.HasUnknownSource == true;
+
+        public bool Add(SourceBinding source)
+        {
+            Sources.Add(source);
+            var unique = true;
+            foreach (var qualifier in source.Qualifiers)
+            {
+                unique &= _qualifiers.TryAdd(qualifier, source);
+            }
+
+            return unique;
+        }
+
+        public SourceBinding? FindQualifier(string qualifier) =>
+            _qualifiers.GetValueOrDefault(qualifier)
+            ?? Parent?.FindQualifier(qualifier);
+
+        public IReadOnlyList<ColumnMatch> FindColumn(string name)
+        {
+            var local = Sources
+                .Where(source => source.Columns.TryGetValue(name, out _))
+                .Select(source => new ColumnMatch(source, source.Columns[name]))
+                .ToArray();
+            return local.Length > 0
+                ? local
+                : Parent?.FindColumn(name) ?? Array.Empty<ColumnMatch>();
+        }
+    }
+
+    private sealed class SourceBinding
+    {
+        private SourceBinding(
+            string name,
+            IReadOnlyDictionary<string, SqlTypeFamily> columns,
+            IReadOnlyList<string> columnOrder,
+            IReadOnlyList<string> qualifiers,
+            TableInfo? table,
+            bool isUnknown)
+        {
+            Name = name;
+            Columns = columns;
+            ColumnOrder = columnOrder;
+            Qualifiers = qualifiers
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            Table = table;
+            IsUnknown = isUnknown;
+        }
+
+        public string Name { get; }
+
+        public IReadOnlyDictionary<string, SqlTypeFamily> Columns { get; }
+
+        public IReadOnlyList<string> ColumnOrder { get; }
+
+        public IReadOnlyList<string> Qualifiers { get; }
+
+        public TableInfo? Table { get; }
+
+        public bool IsUnknown { get; }
+
+        public static SourceBinding FromTable(
+            TableInfo table,
+            string name,
+            IReadOnlyList<string> qualifiers) =>
+            new(
+                name,
+                table.Columns.ToDictionary(
+                    static pair => pair.Key,
+                    static pair => pair.Value.Type,
+                    StringComparer.OrdinalIgnoreCase),
+                table.ColumnOrder,
+                qualifiers,
+                table,
+                false);
+
+        public static SourceBinding FromProjection(
+            string name,
+            Projection projection,
+            string fallbackQualifier,
+            IReadOnlyList<string>? qualifiers = null)
+        {
+            var columns = new Dictionary<string, SqlTypeFamily>(StringComparer.OrdinalIgnoreCase);
+            var order = new List<string>();
+            foreach (var column in projection.Columns)
+            {
+                if (column.Name is null || !columns.TryAdd(column.Name, column.Type)) continue;
+                order.Add(column.Name);
+            }
+
+            return new(
+                name,
+                columns,
+                order,
+                qualifiers ?? [fallbackQualifier],
+                null,
+                false);
+        }
+
+        public static SourceBinding Unknown(
+            string name,
+            IReadOnlyList<string> qualifiers) =>
+            new(
+                name,
+                new Dictionary<string, SqlTypeFamily>(StringComparer.OrdinalIgnoreCase),
+                [],
+                qualifiers,
+                null,
+                true);
+    }
+
+    private sealed record ColumnInfo(string Name, SqlTypeFamily Type, SqlColumnSchema Model);
+
+    private sealed class TableInfo
+    {
+        public required string Key { get; init; }
+
+        public required string SimpleName { get; init; }
+
+        public required string DisplayName { get; init; }
+
+        public required SqlTableSchema Model { get; init; }
+
+        public required IReadOnlyDictionary<string, ColumnInfo> Columns { get; init; }
+
+        public required IReadOnlyList<string> ColumnOrder { get; init; }
+
+        public bool IsUniqueKey(IReadOnlyList<string> columns)
+        {
+            if (columns.Count == 1
+                && Columns.TryGetValue(columns[0], out var column)
+                && (column.Model.IsPrimaryKey || column.Model.IsUnique))
+            {
+                return true;
+            }
+
+            if (Model.PrimaryKey is not null
+                && SetEquals(Model.PrimaryKey, columns))
+            {
+                return true;
+            }
+
+            return Model.UniqueKeys?.Any(key => SetEquals(key, columns)) == true;
+        }
+
+        private static bool SetEquals(
+            IReadOnlyList<string> first,
+            IReadOnlyList<string> second) =>
+            first.Count == second.Count
+            && first.ToHashSet(StringComparer.OrdinalIgnoreCase)
+                .SetEquals(second);
+    }
+
+    private sealed record Relationship(
+        TableInfo Source,
+        IReadOnlyList<string> SourceColumns,
+        TableInfo Target,
+        IReadOnlyList<string> TargetColumns);
+
+    private sealed class CatalogIndex
+    {
+        private readonly Dictionary<string, TableInfo> _tables =
+            new(StringComparer.OrdinalIgnoreCase);
+        private readonly HashSet<string> _ambiguousNames =
+            new(StringComparer.OrdinalIgnoreCase);
+
+        public CatalogIndex(SqlSchemaCatalog catalog)
+        {
+            ArgumentNullException.ThrowIfNull(catalog.Tables);
+            var tables = new List<TableInfo>();
+            foreach (var model in catalog.Tables)
+            {
+                ArgumentException.ThrowIfNullOrWhiteSpace(model.Name);
+                ArgumentNullException.ThrowIfNull(model.Columns);
+                var displayName = model.Schema is null
+                    ? model.Name
+                    : $"{model.Schema}.{model.Name}";
+                var columns = new Dictionary<string, ColumnInfo>(StringComparer.OrdinalIgnoreCase);
+                var order = new List<string>();
+                foreach (var column in model.Columns)
+                {
+                    ArgumentException.ThrowIfNullOrWhiteSpace(column.Name);
+                    ArgumentNullException.ThrowIfNull(column.DataType);
+                    if (!columns.TryAdd(
+                        column.Name,
+                        new ColumnInfo(
+                            column.Name,
+                            SqlTypeFamilies.Classify(column.DataType),
+                            column)))
+                    {
+                        throw new ArgumentException(
+                            $"Table '{displayName}' contains duplicate column '{column.Name}'.",
+                            nameof(catalog));
+                    }
+
+                    order.Add(column.Name);
+                }
+
+                var table = new TableInfo
+                {
+                    Key = displayName,
+                    SimpleName = model.Name,
+                    DisplayName = displayName,
+                    Model = model,
+                    Columns = columns,
+                    ColumnOrder = order,
+                };
+                tables.Add(table);
+                AddName(displayName, table, catalog);
+                if (model.Schema is not null)
+                {
+                    AddPossiblyAmbiguousName(model.Name, table);
+                }
+                if (model.Aliases is not null)
+                {
+                    foreach (var alias in model.Aliases)
+                    {
+                        ArgumentException.ThrowIfNullOrWhiteSpace(alias);
+                        AddName(alias, table, catalog);
+                    }
+                }
+            }
+
+            Tables = tables;
+            Relationships = BuildRelationships();
+        }
+
+        public IReadOnlyList<TableInfo> Tables { get; }
+
+        public IReadOnlyList<Relationship> Relationships { get; }
+
+        public TableInfo? Resolve(TableName name)
+        {
+            var fullName = JoinParts(name.Parts);
+            return _tables.GetValueOrDefault(fullName);
+        }
+
+        public TableInfo? Resolve(string name, string? schema) =>
+            schema is not null
+                ? _tables.GetValueOrDefault($"{schema}.{name}")
+                : _tables.GetValueOrDefault(name);
+
+        public IReadOnlyList<(TableInfo Table, SqlTypeFamily Type)> FindColumn(string name) =>
+            Tables
+                .Where(table => table.Columns.ContainsKey(name))
+                .Select(table => (table, table.Columns[name].Type))
+                .ToArray();
+
+        private void AddName(string name, TableInfo table, SqlSchemaCatalog catalog)
+        {
+            if (_tables.TryGetValue(name, out var existing)
+                && !ReferenceEquals(existing, table))
+            {
+                throw new ArgumentException(
+                    $"Catalog table name or alias '{name}' is ambiguous.",
+                    nameof(catalog));
+            }
+
+            _tables[name] = table;
+        }
+
+        private void AddPossiblyAmbiguousName(string name, TableInfo table)
+        {
+            if (_ambiguousNames.Contains(name)) return;
+            if (_tables.TryGetValue(name, out var existing)
+                && !ReferenceEquals(existing, table))
+            {
+                _tables.Remove(name);
+                _ambiguousNames.Add(name);
+                return;
+            }
+
+            _tables[name] = table;
+        }
+
+        private IReadOnlyList<Relationship> BuildRelationships()
+        {
+            var relationships = new List<Relationship>();
+            foreach (var source in Tables)
+            {
+                foreach (var column in source.Model.Columns)
+                {
+                    if (column.References is null) continue;
+                    var target = Resolve(
+                        column.References.Table,
+                        column.References.Schema);
+                    if (target is not null)
+                    {
+                        relationships.Add(new Relationship(
+                            source,
+                            [column.Name],
+                            target,
+                            [column.References.Column]));
+                    }
+                }
+
+                if (source.Model.ForeignKeys is null) continue;
+                foreach (var foreignKey in source.Model.ForeignKeys)
+                {
+                    var target = Resolve(
+                        foreignKey.References.Table,
+                        foreignKey.References.Schema);
+                    if (target is not null)
+                    {
+                        relationships.Add(new Relationship(
+                            source,
+                            foreignKey.Columns,
+                            target,
+                            foreignKey.References.Columns));
+                    }
+                }
+            }
+
+            return relationships;
+        }
+    }
+}

--- a/src/Cyqwel/Validation/SqlValidationModels.cs
+++ b/src/Cyqwel/Validation/SqlValidationModels.cs
@@ -1,0 +1,239 @@
+using Cyqwel.Ast;
+using Cyqwel.Parsing;
+
+namespace Cyqwel.Validation;
+
+public enum SqlValidationSeverity
+{
+    Warning,
+    Error,
+}
+
+public sealed record SqlValidationLocation(SqlTextSpan Span, int Line, int Column);
+
+public sealed record SqlValidationDiagnostic(
+    SqlValidationSeverity Severity,
+    string Code,
+    string Message,
+    SqlValidationLocation? Location = null);
+
+public sealed record SqlValidationResult(IReadOnlyList<SqlValidationDiagnostic> Diagnostics)
+{
+    public bool IsValid => Diagnostics.All(static diagnostic =>
+        diagnostic.Severity != SqlValidationSeverity.Error);
+}
+
+public sealed record SqlValidationOptions
+{
+    public static SqlValidationOptions Default { get; } = new();
+
+    public bool StrictSyntax { get; init; }
+
+    public bool Semantic { get; init; }
+
+    public SqlParseOptions ParseOptions { get; init; } = SqlParseOptions.Default;
+}
+
+public sealed record SqlSchemaValidationOptions
+{
+    public static SqlSchemaValidationOptions Default { get; } = new();
+
+    public bool StrictSyntax { get; init; }
+
+    public bool Semantic { get; init; }
+
+    public bool Strict { get; init; } = true;
+
+    public bool CheckTypes { get; init; }
+
+    public bool CheckReferences { get; init; }
+
+    public SqlParseOptions ParseOptions { get; init; } = SqlParseOptions.Default;
+}
+
+public sealed record SqlSchemaCatalog(IReadOnlyList<SqlTableSchema> Tables)
+{
+    public SqlSchemaCatalog(params SqlTableSchema[] tables)
+        : this((IReadOnlyList<SqlTableSchema>)tables)
+    {
+    }
+}
+
+public sealed record SqlTableSchema(
+    string Name,
+    IReadOnlyList<SqlColumnSchema> Columns,
+    string? Schema = null,
+    IReadOnlyList<string>? Aliases = null,
+    IReadOnlyList<string>? PrimaryKey = null,
+    IReadOnlyList<IReadOnlyList<string>>? UniqueKeys = null,
+    IReadOnlyList<SqlForeignKey>? ForeignKeys = null);
+
+public sealed record SqlColumnSchema(
+    string Name,
+    string DataType,
+    bool? IsNullable = null,
+    bool IsPrimaryKey = false,
+    bool IsUnique = false,
+    SqlColumnReference? References = null);
+
+public sealed record SqlColumnReference(string Table, string Column, string? Schema = null);
+
+public sealed record SqlForeignKey(
+    IReadOnlyList<string> Columns,
+    SqlTableReference References,
+    string? Name = null);
+
+public sealed record SqlTableReference(
+    string Table,
+    IReadOnlyList<string> Columns,
+    string? Schema = null);
+
+public enum SqlTypeFamily
+{
+    Unknown,
+    Boolean,
+    Integer,
+    Numeric,
+    String,
+    Binary,
+    Date,
+    Time,
+    Timestamp,
+    Interval,
+    Json,
+    Uuid,
+    Array,
+    Map,
+    Struct,
+}
+
+public static class SqlValidationCodes
+{
+    public const string SyntaxError = "E000";
+    public const string StrictSyntax = "E005";
+
+    public const string SelectStar = "W001";
+    public const string AggregateWithoutGroupBy = "W002";
+    public const string DistinctOrderBy = "W003";
+    public const string LimitWithoutOrderBy = "W004";
+
+    public const string UnknownTable = "E200";
+    public const string UnknownColumn = "E201";
+    public const string UnknownFunction = "E202";
+    public const string InvalidFunctionArity = "E203";
+    public const string InvalidScalarSubquery = "E204";
+
+    public const string TypeMismatch = "E210";
+    public const string InvalidPredicateType = "E211";
+    public const string InvalidArithmeticType = "E212";
+    public const string InvalidFunctionArgumentType = "E213";
+    public const string InvalidAssignmentType = "E214";
+    public const string SetOperationTypeMismatch = "E215";
+    public const string SetOperationArityMismatch = "E216";
+    public const string IncompatibleComparisonTypes = "E217";
+
+    public const string ImplicitComparisonCast = "W210";
+    public const string ImplicitArithmeticCast = "W211";
+    public const string ImplicitAssignmentCast = "W212";
+    public const string SetOperationImplicitCoercion = "W214";
+    public const string PredicateTypeConcern = "W215";
+    public const string FunctionArgumentCoercion = "W216";
+
+    public const string InvalidForeignKeyReference = "E220";
+    public const string AmbiguousColumnReference = "E221";
+    public const string UnresolvedReference = "E222";
+    public const string CteColumnCountMismatch = "E223";
+
+    public const string CartesianJoin = "W220";
+    public const string JoinNotUsingDeclaredReference = "W221";
+    public const string WeakReferenceIntegrity = "W222";
+}
+
+public static class SqlTypeFamilies
+{
+    public static SqlTypeFamily Classify(string dataType)
+    {
+        ArgumentNullException.ThrowIfNull(dataType);
+
+        var normalized = dataType
+            .Trim()
+            .Trim('"', '\'', '`')
+            .ToLowerInvariant();
+        if (normalized.Length == 0) return SqlTypeFamily.Unknown;
+
+        if (TryUnwrap(normalized, out var wrapper, out var inner))
+        {
+            if (wrapper is "nullable" or "lowcardinality") return Classify(inner);
+            if (wrapper is "array" or "list") return SqlTypeFamily.Array;
+            if (wrapper == "map") return SqlTypeFamily.Map;
+            if (wrapper is "struct" or "row" or "record") return SqlTypeFamily.Struct;
+        }
+
+        if (normalized.EndsWith("[]", StringComparison.Ordinal)
+            || normalized.StartsWith("array<", StringComparison.Ordinal)
+            || normalized.StartsWith("list<", StringComparison.Ordinal))
+        {
+            return SqlTypeFamily.Array;
+        }
+
+        if (normalized.StartsWith("map<", StringComparison.Ordinal)) return SqlTypeFamily.Map;
+        if (normalized.StartsWith("struct<", StringComparison.Ordinal)
+            || normalized.StartsWith("row<", StringComparison.Ordinal)
+            || normalized.StartsWith("record<", StringComparison.Ordinal)
+            || normalized.StartsWith("object<", StringComparison.Ordinal))
+        {
+            return SqlTypeFamily.Struct;
+        }
+
+        var openParenthesis = normalized.IndexOf('(');
+        if (openParenthesis >= 0) normalized = normalized[..openParenthesis].TrimEnd();
+        normalized = normalized
+            .Replace("unsigned ", "", StringComparison.Ordinal)
+            .Replace(" unsigned", "", StringComparison.Ordinal);
+
+        return normalized switch
+        {
+            "bool" or "boolean" => SqlTypeFamily.Boolean,
+            "tinyint" or "smallint" or "int2" or "int" or "integer" or "int4" or "int8"
+                or "bigint" or "serial" or "smallserial" or "bigserial" or "utinyint"
+                or "usmallint" or "uinteger" or "ubigint" or "uint8" or "uint16" or "uint32"
+                or "uint64" or "int16" or "int32" or "int64" => SqlTypeFamily.Integer,
+            "numeric" or "decimal" or "dec" or "number" or "float" or "float4" or "float8"
+                or "real" or "double" or "double precision" or "bfloat16" or "float16"
+                or "float32" or "float64" => SqlTypeFamily.Numeric,
+            "char" or "character" or "varchar" or "character varying" or "nchar" or "nvarchar"
+                or "text" or "string" or "clob" => SqlTypeFamily.String,
+            "binary" or "varbinary" or "blob" or "bytea" or "bytes" => SqlTypeFamily.Binary,
+            "date" => SqlTypeFamily.Date,
+            "time" => SqlTypeFamily.Time,
+            "timestamp" or "timestamptz" or "datetime" or "datetime2" or "smalldatetime"
+                or "timestamp with time zone" or "timestamp without time zone" =>
+                SqlTypeFamily.Timestamp,
+            "interval" => SqlTypeFamily.Interval,
+            "json" or "jsonb" or "variant" => SqlTypeFamily.Json,
+            "uuid" or "uniqueidentifier" => SqlTypeFamily.Uuid,
+            "array" or "list" => SqlTypeFamily.Array,
+            "map" => SqlTypeFamily.Map,
+            "struct" or "row" or "record" or "object" => SqlTypeFamily.Struct,
+            _ => SqlTypeFamily.Unknown,
+        };
+    }
+
+    private static bool TryUnwrap(
+        string dataType,
+        out string wrapper,
+        out string inner)
+    {
+        var openParenthesis = dataType.IndexOf('(');
+        if (openParenthesis <= 0 || !dataType.EndsWith(')'))
+        {
+            wrapper = "";
+            inner = "";
+            return false;
+        }
+
+        wrapper = dataType[..openParenthesis].Trim();
+        inner = dataType[(openParenthesis + 1)..^1].Trim();
+        return inner.Length > 0;
+    }
+}

--- a/src/Cyqwel/Validation/SqlValidator.cs
+++ b/src/Cyqwel/Validation/SqlValidator.cs
@@ -1,0 +1,463 @@
+using Cyqwel.Ast;
+using Cyqwel.Dialects;
+using Cyqwel.Parsing;
+using Cyqwel.Visitors;
+
+namespace Cyqwel.Validation;
+
+public static class SqlValidator
+{
+    private static readonly HashSet<string> AggregateFunctions =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            "AVG", "COUNT", "MAX", "MIN", "SUM",
+            "ARRAY_AGG", "JSON_AGG", "JSONB_AGG", "STRING_AGG",
+            "BOOL_AND", "BOOL_OR", "EVERY",
+        };
+
+    public static SqlValidationResult Validate(
+        string sql,
+        SqlDialect? dialect = null,
+        SqlValidationOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(sql);
+        options ??= SqlValidationOptions.Default;
+
+        var diagnostics = Parse(
+            sql,
+            dialect ?? SqlDialects.Generic,
+            options.StrictSyntax,
+            options.ParseOptions,
+            out var document);
+        if (document is not null && options.Semantic)
+        {
+            AddSemanticDiagnostics(document, sql, diagnostics);
+        }
+
+        return new SqlValidationResult(diagnostics);
+    }
+
+    public static SqlValidationResult Validate(
+        string sql,
+        SqlSchemaCatalog catalog,
+        SqlDialect? dialect = null,
+        SqlSchemaValidationOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(sql);
+        ArgumentNullException.ThrowIfNull(catalog);
+        options ??= SqlSchemaValidationOptions.Default;
+
+        var diagnostics = Parse(
+            sql,
+            dialect ?? SqlDialects.Generic,
+            options.StrictSyntax,
+            options.ParseOptions,
+            out var document);
+        if (document is null) return new SqlValidationResult(diagnostics);
+
+        if (options.Semantic) AddSemanticDiagnostics(document, sql, diagnostics);
+        new SchemaValidationEngine(sql, catalog, options, diagnostics).Validate(document);
+        return new SqlValidationResult(diagnostics);
+    }
+
+    internal static bool IsAggregateFunction(string name) => AggregateFunctions.Contains(name);
+
+    private static List<SqlValidationDiagnostic> Parse(
+        string sql,
+        SqlDialect dialect,
+        bool strictSyntax,
+        SqlParseOptions parseOptions,
+        out SqlDocument? document)
+    {
+        ArgumentNullException.ThrowIfNull(parseOptions);
+        var diagnostics = new List<SqlValidationDiagnostic>();
+
+        if (strictSyntax && TryFindTrailingComma(sql, out var offset))
+        {
+            diagnostics.Add(new SqlValidationDiagnostic(
+                SqlValidationSeverity.Error,
+                SqlValidationCodes.StrictSyntax,
+                "Trailing commas are not allowed in strict syntax mode.",
+                CreateLocation(sql, offset, 1)));
+            document = null;
+            return diagnostics;
+        }
+
+        var parseSql = strictSyntax ? sql : RemoveTrailingCommas(sql);
+        if (!SqlParser.TryParse(parseSql, dialect, out document, out var error, parseOptions))
+        {
+            diagnostics.Add(new SqlValidationDiagnostic(
+                SqlValidationSeverity.Error,
+                SqlValidationCodes.SyntaxError,
+                error!.Message,
+                new SqlValidationLocation(
+                    new SqlTextSpan(error.Offset, 0),
+                    error.Line,
+                    error.Column)));
+        }
+
+        return diagnostics;
+    }
+
+    private static void AddSemanticDiagnostics(
+        SqlDocument document,
+        string sql,
+        List<SqlValidationDiagnostic> diagnostics)
+    {
+        foreach (var select in document.FindAll<SelectStatement>())
+        {
+            foreach (var projection in select.Projections)
+            {
+                if (projection.Expression is StarExpression)
+                {
+                    diagnostics.Add(Warning(
+                        SqlValidationCodes.SelectStar,
+                        "SELECT * can make queries fragile when schemas change.",
+                        sql,
+                        projection.Expression));
+                }
+            }
+
+            if (select.GroupBy is not { Count: > 0 }
+                && select.Projections.Any(static projection =>
+                    ContainsAggregate(projection.Expression))
+                && select.Projections.Any(static projection =>
+                    ContainsUngroupedColumn(projection.Expression)))
+            {
+                diagnostics.Add(Warning(
+                    SqlValidationCodes.AggregateWithoutGroupBy,
+                    "Aggregate and non-aggregate projections are mixed without GROUP BY.",
+                    sql,
+                    select));
+            }
+
+            if (select.IsDistinct && select.OrderBy is { Count: > 0 })
+            {
+                var projected = select.Projections
+                    .Select(static projection => ExpressionKey(projection.Expression))
+                    .ToHashSet(StringComparer.OrdinalIgnoreCase);
+                var aliases = select.Projections
+                    .Where(static projection => projection.Alias is not null)
+                    .Select(static projection => projection.Alias!.Value)
+                    .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+                foreach (var orderBy in select.OrderBy)
+                {
+                    var isOrdinal = orderBy.Expression is LiteralExpression
+                    {
+                        Value: sbyte or byte or short or ushort or int or uint or long or ulong,
+                    };
+                    var isAlias = orderBy.Expression is ColumnExpression { Parts.Count: 1 } column
+                        && aliases.Contains(column.Parts[0].Value);
+                    if (!isOrdinal
+                        && !isAlias
+                        && !projected.Contains(ExpressionKey(orderBy.Expression)))
+                    {
+                        diagnostics.Add(Warning(
+                            SqlValidationCodes.DistinctOrderBy,
+                            "ORDER BY expression is not present in the DISTINCT projection.",
+                            sql,
+                            orderBy.Expression));
+                    }
+                }
+            }
+
+            if ((select.Limit is not null || select.Offset is not null)
+                && select.OrderBy is not { Count: > 0 })
+            {
+                diagnostics.Add(Warning(
+                    SqlValidationCodes.LimitWithoutOrderBy,
+                    "LIMIT or OFFSET without ORDER BY does not produce deterministic rows.",
+                    sql,
+                    select.Limit ?? select.Offset!));
+            }
+        }
+
+        foreach (var values in document.FindAll<ValuesStatement>())
+        {
+            if ((values.Limit is not null || values.Offset is not null)
+                && values.OrderBy is not { Count: > 0 })
+            {
+                diagnostics.Add(Warning(
+                    SqlValidationCodes.LimitWithoutOrderBy,
+                    "LIMIT or OFFSET without ORDER BY does not produce deterministic rows.",
+                    sql,
+                    values.Limit ?? values.Offset!));
+            }
+        }
+
+        foreach (var set in document.FindAll<SetOperationStatement>())
+        {
+            if ((set.Limit is not null || set.Offset is not null)
+                && set.OrderBy is not { Count: > 0 })
+            {
+                diagnostics.Add(Warning(
+                    SqlValidationCodes.LimitWithoutOrderBy,
+                    "LIMIT or OFFSET without ORDER BY does not produce deterministic rows.",
+                    sql,
+                    set.Limit ?? set.Offset!));
+            }
+        }
+    }
+
+    private static bool ContainsAggregate(SqlExpression expression) => expression switch
+    {
+        WindowExpression => false,
+        SubqueryExpression or ExistsExpression => false,
+        FunctionCallExpression function when IsAggregateFunction(function.Name.Value) => true,
+        FunctionCallExpression function => function.Arguments.Any(ContainsAggregate),
+        ParenthesizedExpression value => ContainsAggregate(value.Expression),
+        UnaryExpression value => ContainsAggregate(value.Operand),
+        BinaryExpression value => ContainsAggregate(value.Left) || ContainsAggregate(value.Right),
+        BetweenExpression value => ContainsAggregate(value.Expression)
+            || ContainsAggregate(value.Lower)
+            || ContainsAggregate(value.Upper),
+        InExpression value => ContainsAggregate(value.Expression)
+            || value.Values.Any(ContainsAggregate),
+        IsNullExpression value => ContainsAggregate(value.Expression),
+        BooleanTestExpression value => ContainsAggregate(value.Expression),
+        DistinctFromExpression value => ContainsAggregate(value.Left)
+            || ContainsAggregate(value.Right),
+        RowExpression value => value.Values.Any(ContainsAggregate),
+        CollateExpression value => ContainsAggregate(value.Expression),
+        ExtractExpression value => ContainsAggregate(value.Expression),
+        IntervalExpression value => ContainsAggregate(value.Value),
+        CaseExpression value => (value.Operand is not null && ContainsAggregate(value.Operand))
+            || value.Whens.Any(static when =>
+                ContainsAggregate(when.Condition) || ContainsAggregate(when.Result))
+            || (value.Else is not null && ContainsAggregate(value.Else)),
+        CastExpression value => ContainsAggregate(value.Expression),
+        TryCastExpression value => ContainsAggregate(value.Expression),
+        _ => false,
+    };
+
+    private static bool ContainsUngroupedColumn(SqlExpression expression) => expression switch
+    {
+        ColumnExpression => true,
+        WindowExpression or SubqueryExpression or ExistsExpression => false,
+        FunctionCallExpression function when IsAggregateFunction(function.Name.Value) => false,
+        FunctionCallExpression function => function.Arguments.Any(ContainsUngroupedColumn),
+        ParenthesizedExpression value => ContainsUngroupedColumn(value.Expression),
+        UnaryExpression value => ContainsUngroupedColumn(value.Operand),
+        BinaryExpression value => ContainsUngroupedColumn(value.Left)
+            || ContainsUngroupedColumn(value.Right),
+        BetweenExpression value => ContainsUngroupedColumn(value.Expression)
+            || ContainsUngroupedColumn(value.Lower)
+            || ContainsUngroupedColumn(value.Upper),
+        InExpression value => ContainsUngroupedColumn(value.Expression)
+            || value.Values.Any(ContainsUngroupedColumn),
+        IsNullExpression value => ContainsUngroupedColumn(value.Expression),
+        BooleanTestExpression value => ContainsUngroupedColumn(value.Expression),
+        DistinctFromExpression value => ContainsUngroupedColumn(value.Left)
+            || ContainsUngroupedColumn(value.Right),
+        RowExpression value => value.Values.Any(ContainsUngroupedColumn),
+        CollateExpression value => ContainsUngroupedColumn(value.Expression),
+        ExtractExpression value => ContainsUngroupedColumn(value.Expression),
+        IntervalExpression value => ContainsUngroupedColumn(value.Value),
+        CaseExpression value => (value.Operand is not null && ContainsUngroupedColumn(value.Operand))
+            || value.Whens.Any(static when =>
+                ContainsUngroupedColumn(when.Condition)
+                || ContainsUngroupedColumn(when.Result))
+            || (value.Else is not null && ContainsUngroupedColumn(value.Else)),
+        CastExpression value => ContainsUngroupedColumn(value.Expression),
+        TryCastExpression value => ContainsUngroupedColumn(value.Expression),
+        _ => false,
+    };
+
+    private static string ExpressionKey(SqlExpression expression) =>
+        expression.ToSql(SqlDialects.Generic);
+
+    private static SqlValidationDiagnostic Warning(
+        string code,
+        string message,
+        string sql,
+        SqlNode node) =>
+        new(
+            SqlValidationSeverity.Warning,
+            code,
+            message,
+            CreateLocation(sql, node));
+
+    internal static SqlValidationLocation? CreateLocation(string sql, SqlNode node) =>
+        node.Span.IsEmpty ? null : CreateLocation(sql, node.Span.Start, node.Span.Length);
+
+    internal static SqlValidationLocation CreateLocation(string sql, int offset, int length)
+    {
+        var line = 1;
+        var column = 1;
+        for (var i = 0; i < offset && i < sql.Length; i++)
+        {
+            if (sql[i] == '\n')
+            {
+                line++;
+                column = 1;
+            }
+            else
+            {
+                column++;
+            }
+        }
+
+        return new SqlValidationLocation(new SqlTextSpan(offset, length), line, column);
+    }
+
+    private static bool TryFindTrailingComma(string sql, out int offset)
+    {
+        var offsets = FindTrailingCommaOffsets(sql);
+        if (offsets.Count > 0)
+        {
+            offset = offsets[0];
+            return true;
+        }
+
+        offset = -1;
+        return false;
+    }
+
+    private static string RemoveTrailingCommas(string sql)
+    {
+        var offsets = FindTrailingCommaOffsets(sql);
+        if (offsets.Count == 0) return sql;
+
+        var characters = sql.ToCharArray();
+        foreach (var offset in offsets) characters[offset] = ' ';
+        return new string(characters);
+    }
+
+    private static IReadOnlyList<int> FindTrailingCommaOffsets(string sql)
+    {
+        var offsets = new List<int>();
+        for (var i = 0; i < sql.Length; i++)
+        {
+            if (TrySkipQuotedOrComment(sql, ref i)) continue;
+            if (sql[i] != ',') continue;
+
+            var next = i + 1;
+            SkipTrivia(sql, ref next);
+            if (next >= sql.Length || sql[next] is ')' or ';')
+            {
+                offsets.Add(i);
+                continue;
+            }
+
+            if (!IsIdentifierStart(sql[next])) continue;
+            var end = next + 1;
+            while (end < sql.Length && IsIdentifierPart(sql[end])) end++;
+            var keyword = sql[next..end];
+            if (keyword.Equals("FROM", StringComparison.OrdinalIgnoreCase)
+                || keyword.Equals("WHERE", StringComparison.OrdinalIgnoreCase)
+                || keyword.Equals("GROUP", StringComparison.OrdinalIgnoreCase)
+                || keyword.Equals("HAVING", StringComparison.OrdinalIgnoreCase)
+                || keyword.Equals("ORDER", StringComparison.OrdinalIgnoreCase)
+                || keyword.Equals("LIMIT", StringComparison.OrdinalIgnoreCase)
+                || keyword.Equals("OFFSET", StringComparison.OrdinalIgnoreCase)
+                || keyword.Equals("FETCH", StringComparison.OrdinalIgnoreCase)
+                || keyword.Equals("RETURNING", StringComparison.OrdinalIgnoreCase))
+            {
+                offsets.Add(i);
+            }
+        }
+
+        return offsets;
+    }
+
+    private static void SkipTrivia(string sql, ref int index)
+    {
+        while (index < sql.Length)
+        {
+            if (char.IsWhiteSpace(sql[index]))
+            {
+                index++;
+                continue;
+            }
+
+            if (index + 1 < sql.Length && sql[index] == '-' && sql[index + 1] == '-')
+            {
+                index += 2;
+                while (index < sql.Length && sql[index] != '\n') index++;
+                continue;
+            }
+
+            if (index + 1 < sql.Length && sql[index] == '/' && sql[index + 1] == '*')
+            {
+                index += 2;
+                while (index + 1 < sql.Length
+                    && !(sql[index] == '*' && sql[index + 1] == '/'))
+                {
+                    index++;
+                }
+
+                index = Math.Min(index + 2, sql.Length);
+                continue;
+            }
+
+            break;
+        }
+    }
+
+    private static bool TrySkipQuotedOrComment(string sql, ref int index)
+    {
+        var current = sql[index];
+        if (current is '\'' or '"' or '`')
+        {
+            var quote = current;
+            while (++index < sql.Length)
+            {
+                if (sql[index] != quote) continue;
+                if (index + 1 < sql.Length && sql[index + 1] == quote)
+                {
+                    index++;
+                    continue;
+                }
+
+                return true;
+            }
+
+            return true;
+        }
+
+        if (current == '[')
+        {
+            while (++index < sql.Length)
+            {
+                if (sql[index] != ']') continue;
+                if (index + 1 < sql.Length && sql[index + 1] == ']')
+                {
+                    index++;
+                    continue;
+                }
+
+                return true;
+            }
+
+            return true;
+        }
+
+        if (index + 1 < sql.Length && current == '-' && sql[index + 1] == '-')
+        {
+            index += 2;
+            while (index < sql.Length && sql[index] != '\n') index++;
+            return true;
+        }
+
+        if (index + 1 < sql.Length && current == '/' && sql[index + 1] == '*')
+        {
+            index += 2;
+            while (index + 1 < sql.Length
+                && !(sql[index] == '*' && sql[index + 1] == '/'))
+            {
+                index++;
+            }
+
+            index = Math.Min(index + 1, sql.Length - 1);
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsIdentifierStart(char value) => value == '_' || char.IsLetter(value);
+
+    private static bool IsIdentifierPart(char value) =>
+        value is '_' or '$' || char.IsLetterOrDigit(value);
+}

--- a/tests/Cyqwel.Tests/SqlValidationReferenceTests.cs
+++ b/tests/Cyqwel.Tests/SqlValidationReferenceTests.cs
@@ -1,0 +1,120 @@
+using Cyqwel.Validation;
+
+namespace Cyqwel.Tests;
+
+public class SqlValidationReferenceTests
+{
+    [Fact]
+    public void Valid_foreign_key_metadata_is_accepted()
+    {
+        var result = SqlValidator.Validate(
+            "SELECT 1",
+            ValidationTestCatalog.Create(withRelationship: true),
+            options: new SqlSchemaValidationOptions { CheckReferences = true });
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void Invalid_foreign_key_targets_are_reported()
+    {
+        var catalog = new SqlSchemaCatalog(
+            new SqlTableSchema(
+                "orders",
+                [
+                    new(
+                        "user_id",
+                        "integer",
+                        References: new SqlColumnReference("missing_users", "id")),
+                ]));
+
+        var result = SqlValidator.Validate(
+            "SELECT 1",
+            catalog,
+            options: new SqlSchemaValidationOptions { CheckReferences = true });
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Diagnostics, diagnostic =>
+            diagnostic.Code == SqlValidationCodes.InvalidForeignKeyReference);
+    }
+
+    [Fact]
+    public void Invalid_foreign_keys_warn_in_non_strict_mode()
+    {
+        var catalog = new SqlSchemaCatalog(
+            new SqlTableSchema(
+                "orders",
+                [
+                    new(
+                        "user_id",
+                        "integer",
+                        References: new SqlColumnReference("missing_users", "id")),
+                ]));
+
+        var result = SqlValidator.Validate(
+            "SELECT 1",
+            catalog,
+            options: new SqlSchemaValidationOptions
+            {
+                CheckReferences = true,
+                Strict = false,
+            });
+
+        Assert.True(result.IsValid);
+        Assert.Contains(result.Diagnostics, diagnostic =>
+            diagnostic.Code == SqlValidationCodes.WeakReferenceIntegrity
+            && diagnostic.Severity == SqlValidationSeverity.Warning);
+    }
+
+    [Fact]
+    public void Ambiguous_unqualified_columns_are_reported()
+    {
+        var result = SqlValidator.Validate(
+            "SELECT id FROM users JOIN orders ON users.id = orders.user_id",
+            ValidationTestCatalog.Create(),
+            options: new SqlSchemaValidationOptions { CheckReferences = true });
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Diagnostics, diagnostic =>
+            diagnostic.Code == SqlValidationCodes.AmbiguousColumnReference);
+    }
+
+    [Fact]
+    public void Cartesian_joins_warn()
+    {
+        var result = SqlValidator.Validate(
+            "SELECT users.id FROM users CROSS JOIN orders",
+            ValidationTestCatalog.Create(),
+            options: new SqlSchemaValidationOptions { CheckReferences = true });
+
+        Assert.True(result.IsValid);
+        Assert.Contains(result.Diagnostics, diagnostic =>
+            diagnostic.Code == SqlValidationCodes.CartesianJoin);
+    }
+
+    [Fact]
+    public void Joins_using_declared_relationships_do_not_warn()
+    {
+        var result = SqlValidator.Validate(
+            "SELECT u.id FROM users u JOIN orders o ON u.id = o.user_id",
+            ValidationTestCatalog.Create(withRelationship: true),
+            options: new SqlSchemaValidationOptions { CheckReferences = true });
+
+        Assert.DoesNotContain(result.Diagnostics, diagnostic =>
+            diagnostic.Code == SqlValidationCodes.JoinNotUsingDeclaredReference);
+    }
+
+    [Fact]
+    public void Joins_ignoring_declared_relationships_warn()
+    {
+        var result = SqlValidator.Validate(
+            "SELECT u.id FROM users u JOIN orders o ON u.age = o.total",
+            ValidationTestCatalog.Create(withRelationship: true),
+            options: new SqlSchemaValidationOptions { CheckReferences = true });
+
+        Assert.True(result.IsValid);
+        Assert.Contains(result.Diagnostics, diagnostic =>
+            diagnostic.Code == SqlValidationCodes.JoinNotUsingDeclaredReference);
+    }
+}

--- a/tests/Cyqwel.Tests/SqlValidationSchemaTests.cs
+++ b/tests/Cyqwel.Tests/SqlValidationSchemaTests.cs
@@ -1,0 +1,167 @@
+using Cyqwel.Validation;
+
+namespace Cyqwel.Tests;
+
+public class SqlValidationSchemaTests
+{
+    private static readonly SqlSchemaCatalog Catalog = ValidationTestCatalog.Create();
+
+    [Fact]
+    public void Known_tables_and_columns_are_valid()
+    {
+        var result = SqlValidator.Validate(
+            "SELECT id, name, email FROM users",
+            Catalog);
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void Unknown_tables_are_errors_in_strict_mode()
+    {
+        var result = SqlValidator.Validate("SELECT * FROM missing", Catalog);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Diagnostics, diagnostic =>
+            diagnostic.Code == SqlValidationCodes.UnknownTable
+            && diagnostic.Severity == SqlValidationSeverity.Error);
+    }
+
+    [Fact]
+    public void Unknown_columns_are_warnings_in_non_strict_mode()
+    {
+        var result = SqlValidator.Validate(
+            "SELECT missing FROM users",
+            Catalog,
+            options: new SqlSchemaValidationOptions { Strict = false });
+
+        Assert.True(result.IsValid);
+        Assert.Contains(result.Diagnostics, diagnostic =>
+            diagnostic.Code == SqlValidationCodes.UnknownColumn
+            && diagnostic.Severity == SqlValidationSeverity.Warning);
+    }
+
+    [Fact]
+    public void Qualified_columns_and_table_aliases_resolve()
+    {
+        var result = SqlValidator.Validate(
+            "SELECT u.id, o.total FROM users u JOIN orders o ON u.id = o.user_id",
+            Catalog);
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void Unknown_qualifiers_are_reported()
+    {
+        var result = SqlValidator.Validate(
+            "SELECT q.id FROM users u",
+            Catalog);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Diagnostics, diagnostic =>
+            diagnostic.Code == SqlValidationCodes.UnresolvedReference);
+    }
+
+    [Fact]
+    public void Explicit_schema_names_do_not_fall_back_to_another_schema()
+    {
+        var catalog = new SqlSchemaCatalog(
+            new SqlTableSchema("users", [new("id", "integer")], Schema: "public"));
+
+        var known = SqlValidator.Validate("SELECT id FROM public.users", catalog);
+        var unknown = SqlValidator.Validate("SELECT id FROM private.users", catalog);
+
+        Assert.True(known.IsValid);
+        Assert.Contains(unknown.Diagnostics, diagnostic =>
+            diagnostic.Code == SqlValidationCodes.UnknownTable);
+    }
+
+    [Fact]
+    public void Cte_projected_aliases_resolve()
+    {
+        var result = SqlValidator.Validate(
+            "WITH selected AS (SELECT id AS user_id FROM users) SELECT user_id FROM selected",
+            Catalog);
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void Unknown_cte_columns_are_reported()
+    {
+        var result = SqlValidator.Validate(
+            "WITH selected AS (SELECT id AS user_id FROM users) SELECT missing FROM selected",
+            Catalog);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Diagnostics, diagnostic =>
+            diagnostic.Code == SqlValidationCodes.UnknownColumn);
+    }
+
+    [Fact]
+    public void Cte_declared_column_count_is_checked()
+    {
+        var result = SqlValidator.Validate(
+            "WITH selected(one, two) AS (SELECT id FROM users) SELECT one FROM selected",
+            Catalog);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Diagnostics, diagnostic =>
+            diagnostic.Code == SqlValidationCodes.CteColumnCountMismatch);
+    }
+
+    [Fact]
+    public void Derived_table_columns_resolve()
+    {
+        var result = SqlValidator.Validate(
+            "SELECT d.user_id FROM (SELECT id AS user_id FROM users) d",
+            Catalog);
+
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void Recursive_ctes_without_declared_columns_self_resolve()
+    {
+        var result = SqlValidator.Validate(
+            """
+            WITH RECURSIVE numbers AS (
+                SELECT 1 AS n
+                UNION ALL
+                SELECT n + 1 FROM numbers WHERE n < 3
+            )
+            SELECT n FROM numbers
+            """,
+            Catalog);
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void Scalar_subqueries_must_project_one_column()
+    {
+        var result = SqlValidator.Validate(
+            "SELECT (SELECT id, name FROM users) FROM users",
+            Catalog);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Diagnostics, diagnostic =>
+            diagnostic.Code == SqlValidationCodes.InvalidScalarSubquery);
+    }
+
+    [Fact]
+    public void Globally_known_columns_can_be_validated_without_from()
+    {
+        var catalog = new SqlSchemaCatalog(
+            new SqlTableSchema("settings", [new("value", "varchar")]));
+
+        var result = SqlValidator.Validate("SELECT value", catalog);
+
+        Assert.True(result.IsValid);
+    }
+}

--- a/tests/Cyqwel.Tests/SqlValidationSemanticTests.cs
+++ b/tests/Cyqwel.Tests/SqlValidationSemanticTests.cs
@@ -1,0 +1,95 @@
+using Cyqwel.Validation;
+
+namespace Cyqwel.Tests;
+
+public class SqlValidationSemanticTests
+{
+    [Fact]
+    public void Semantic_checks_warn_for_select_star()
+    {
+        var result = SqlValidator.Validate(
+            "SELECT * FROM users",
+            options: new SqlValidationOptions { Semantic = true });
+
+        Assert.True(result.IsValid);
+        Assert.Contains(result.Diagnostics, diagnostic =>
+            diagnostic.Code == SqlValidationCodes.SelectStar
+            && diagnostic.Severity == SqlValidationSeverity.Warning);
+    }
+
+    [Fact]
+    public void Semantic_checks_are_opt_in()
+    {
+        var result = SqlValidator.Validate("SELECT * FROM users");
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void Mixed_aggregate_projections_without_group_by_warn()
+    {
+        var result = SqlValidator.Validate(
+            "SELECT user_id, SUM(total) FROM orders",
+            options: new SqlValidationOptions { Semantic = true });
+
+        Assert.Contains(result.Diagnostics, diagnostic =>
+            diagnostic.Code == SqlValidationCodes.AggregateWithoutGroupBy);
+    }
+
+    [Fact]
+    public void Grouped_aggregate_projections_do_not_warn()
+    {
+        var result = SqlValidator.Validate(
+            "SELECT user_id, SUM(total) FROM orders GROUP BY user_id",
+            options: new SqlValidationOptions { Semantic = true });
+
+        Assert.DoesNotContain(result.Diagnostics, diagnostic =>
+            diagnostic.Code == SqlValidationCodes.AggregateWithoutGroupBy);
+    }
+
+    [Fact]
+    public void Distinct_order_by_non_projected_expression_warns()
+    {
+        var result = SqlValidator.Validate(
+            "SELECT DISTINCT name FROM users ORDER BY age",
+            options: new SqlValidationOptions { Semantic = true });
+
+        Assert.Contains(result.Diagnostics, diagnostic =>
+            diagnostic.Code == SqlValidationCodes.DistinctOrderBy);
+    }
+
+    [Fact]
+    public void Distinct_order_by_projection_alias_does_not_warn()
+    {
+        var result = SqlValidator.Validate(
+            "SELECT DISTINCT name AS display_name FROM users ORDER BY display_name",
+            options: new SqlValidationOptions { Semantic = true });
+
+        Assert.DoesNotContain(result.Diagnostics, diagnostic =>
+            diagnostic.Code == SqlValidationCodes.DistinctOrderBy);
+    }
+
+    [Theory]
+    [InlineData("SELECT id FROM users LIMIT 10")]
+    [InlineData("SELECT id FROM users OFFSET 10")]
+    public void Non_deterministic_row_limiting_warns(string sql)
+    {
+        var result = SqlValidator.Validate(
+            sql,
+            options: new SqlValidationOptions { Semantic = true });
+
+        Assert.Contains(result.Diagnostics, diagnostic =>
+            diagnostic.Code == SqlValidationCodes.LimitWithoutOrderBy);
+    }
+
+    [Fact]
+    public void Ordered_row_limiting_does_not_warn()
+    {
+        var result = SqlValidator.Validate(
+            "SELECT id FROM users ORDER BY id LIMIT 10",
+            options: new SqlValidationOptions { Semantic = true });
+
+        Assert.DoesNotContain(result.Diagnostics, diagnostic =>
+            diagnostic.Code == SqlValidationCodes.LimitWithoutOrderBy);
+    }
+}

--- a/tests/Cyqwel.Tests/SqlValidationSyntaxTests.cs
+++ b/tests/Cyqwel.Tests/SqlValidationSyntaxTests.cs
@@ -1,0 +1,82 @@
+using Cyqwel.Dialects;
+using Cyqwel.Validation;
+
+namespace Cyqwel.Tests;
+
+public class SqlValidationSyntaxTests
+{
+    [Fact]
+    public void Valid_sql_has_no_diagnostics()
+    {
+        var result = SqlValidator.Validate(
+            "SELECT id, name FROM users WHERE id > 0 ORDER BY name LIMIT 10");
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void Parser_errors_are_structured_diagnostics_with_locations()
+    {
+        var result = SqlValidator.Validate("SELECT 1 +");
+
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.False(result.IsValid);
+        Assert.Equal(SqlValidationCodes.SyntaxError, diagnostic.Code);
+        Assert.Equal(SqlValidationSeverity.Error, diagnostic.Severity);
+        Assert.NotNull(diagnostic.Location);
+        Assert.True(diagnostic.Location!.Span.Start >= 0);
+        Assert.True(diagnostic.Location.Line >= 1);
+        Assert.True(diagnostic.Location.Column >= 1);
+    }
+
+    [Fact]
+    public void Strict_syntax_rejects_trailing_projection_commas()
+    {
+        var result = SqlValidator.Validate(
+            "SELECT name, FROM employees",
+            options: new SqlValidationOptions { StrictSyntax = true });
+
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.False(result.IsValid);
+        Assert.Equal(SqlValidationCodes.StrictSyntax, diagnostic.Code);
+        Assert.Equal(11, diagnostic.Location!.Span.Start);
+    }
+
+    [Fact]
+    public void Permissive_syntax_accepts_trailing_projection_commas()
+    {
+        var result = SqlValidator.Validate("SELECT name, FROM employees");
+
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void Strict_syntax_takes_precedence_over_semantic_checks()
+    {
+        var result = SqlValidator.Validate(
+            "SELECT *, FROM employees",
+            options: new SqlValidationOptions
+            {
+                StrictSyntax = true,
+                Semantic = true,
+            });
+
+        Assert.Collection(
+            result.Diagnostics,
+            diagnostic => Assert.Equal(SqlValidationCodes.StrictSyntax, diagnostic.Code));
+    }
+
+    [Fact]
+    public void Dialect_parser_diagnostics_are_preserved()
+    {
+        var result = SqlValidator.Validate(
+            "SELECT TOP 1 id FROM users",
+            SqlDialects.PostgreSql);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(
+            SqlValidationCodes.SyntaxError,
+            Assert.Single(result.Diagnostics).Code);
+    }
+}

--- a/tests/Cyqwel.Tests/SqlValidationTypeTests.cs
+++ b/tests/Cyqwel.Tests/SqlValidationTypeTests.cs
@@ -1,0 +1,161 @@
+using Cyqwel.Validation;
+
+namespace Cyqwel.Tests;
+
+public class SqlValidationTypeTests
+{
+    private static readonly SqlSchemaCatalog Catalog = ValidationTestCatalog.Create();
+    private static readonly SqlSchemaValidationOptions Options = new() { CheckTypes = true };
+
+    [Theory]
+    [InlineData("INT4", SqlTypeFamily.Integer)]
+    [InlineData("double precision", SqlTypeFamily.Numeric)]
+    [InlineData("VARCHAR(255)", SqlTypeFamily.String)]
+    [InlineData("Nullable(Int64)", SqlTypeFamily.Integer)]
+    [InlineData("Array(String)", SqlTypeFamily.Array)]
+    [InlineData("STRUCT<a INT>", SqlTypeFamily.Struct)]
+    public void Schema_types_are_classified(string dataType, SqlTypeFamily expected)
+    {
+        Assert.Equal(expected, SqlTypeFamilies.Classify(dataType));
+    }
+
+    [Fact]
+    public void Incompatible_comparisons_are_reported()
+    {
+        var result = SqlValidator.Validate(
+            "SELECT id FROM users WHERE age = 'old'",
+            Catalog,
+            options: Options);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Diagnostics, diagnostic =>
+            diagnostic.Code == SqlValidationCodes.IncompatibleComparisonTypes);
+    }
+
+    [Fact]
+    public void Invalid_arithmetic_is_reported()
+    {
+        var result = SqlValidator.Validate(
+            "SELECT age + name FROM users",
+            Catalog,
+            options: Options);
+
+        Assert.Contains(result.Diagnostics, diagnostic =>
+            diagnostic.Code == SqlValidationCodes.InvalidArithmeticType);
+    }
+
+    [Fact]
+    public void Non_boolean_predicates_are_reported()
+    {
+        var result = SqlValidator.Validate(
+            "SELECT id FROM users WHERE age + 1",
+            Catalog,
+            options: Options);
+
+        Assert.Contains(result.Diagnostics, diagnostic =>
+            diagnostic.Code == SqlValidationCodes.InvalidPredicateType);
+    }
+
+    [Fact]
+    public void Function_argument_types_and_arity_are_checked()
+    {
+        var typeResult = SqlValidator.Validate(
+            "SELECT ABS(name) FROM users",
+            Catalog,
+            options: Options);
+        var arityResult = SqlValidator.Validate(
+            "SELECT ABS(age, id) FROM users",
+            Catalog,
+            options: Options);
+
+        Assert.Contains(typeResult.Diagnostics, diagnostic =>
+            diagnostic.Code == SqlValidationCodes.InvalidFunctionArgumentType);
+        Assert.Contains(arityResult.Diagnostics, diagnostic =>
+            diagnostic.Code == SqlValidationCodes.InvalidFunctionArity);
+    }
+
+    [Theory]
+    [InlineData("INSERT INTO users (age) VALUES ('old')")]
+    [InlineData("INSERT INTO users (age) SELECT name FROM users")]
+    [InlineData("UPDATE users SET age = name")]
+    public void Dml_assignment_types_are_checked(string sql)
+    {
+        var result = SqlValidator.Validate(sql, Catalog, options: Options);
+
+        Assert.Contains(result.Diagnostics, diagnostic =>
+            diagnostic.Code == SqlValidationCodes.InvalidAssignmentType);
+    }
+
+    [Fact]
+    public void Merge_insert_assignment_types_are_checked()
+    {
+        var result = SqlValidator.Validate(
+            """
+            MERGE INTO users u
+            USING orders o
+            ON u.id = o.user_id
+            WHEN NOT MATCHED THEN INSERT (age) VALUES (o.description)
+            """,
+            Catalog,
+            options: Options);
+
+        Assert.Contains(result.Diagnostics, diagnostic =>
+            diagnostic.Code == SqlValidationCodes.InvalidAssignmentType);
+    }
+
+    [Fact]
+    public void Intervals_are_not_assignable_to_timestamp_columns()
+    {
+        var catalog = new SqlSchemaCatalog(
+            new SqlTableSchema(
+                "events",
+                [
+                    new("started_at", "timestamp"),
+                    new("duration", "interval"),
+                ]));
+
+        var result = SqlValidator.Validate(
+            "UPDATE events SET started_at = INTERVAL '1' DAY",
+            catalog,
+            options: Options);
+
+        Assert.Contains(result.Diagnostics, diagnostic =>
+            diagnostic.Code == SqlValidationCodes.InvalidAssignmentType);
+    }
+
+    [Fact]
+    public void Set_operation_arity_and_types_are_checked()
+    {
+        var arity = SqlValidator.Validate(
+            "SELECT id FROM users UNION SELECT id, total FROM orders",
+            Catalog,
+            options: Options);
+        var types = SqlValidator.Validate(
+            "SELECT age FROM users UNION SELECT name FROM users",
+            Catalog,
+            options: Options);
+
+        Assert.Contains(arity.Diagnostics, diagnostic =>
+            diagnostic.Code == SqlValidationCodes.SetOperationArityMismatch);
+        Assert.Contains(types.Diagnostics, diagnostic =>
+            diagnostic.Code == SqlValidationCodes.SetOperationTypeMismatch);
+    }
+
+    [Fact]
+    public void Non_strict_type_issues_are_warnings()
+    {
+        var result = SqlValidator.Validate(
+            "UPDATE users SET age = name",
+            Catalog,
+            options: new SqlSchemaValidationOptions
+            {
+                CheckTypes = true,
+                Strict = false,
+            });
+
+        Assert.True(result.IsValid);
+        Assert.Contains(result.Diagnostics, diagnostic =>
+            diagnostic.Code == SqlValidationCodes.ImplicitAssignmentCast
+            && diagnostic.Severity == SqlValidationSeverity.Warning);
+    }
+}

--- a/tests/Cyqwel.Tests/ValidationTestCatalog.cs
+++ b/tests/Cyqwel.Tests/ValidationTestCatalog.cs
@@ -1,0 +1,33 @@
+using Cyqwel.Validation;
+
+namespace Cyqwel.Tests;
+
+internal static class ValidationTestCatalog
+{
+    public static SqlSchemaCatalog Create(bool withRelationship = false) =>
+        new(
+            new SqlTableSchema(
+                "users",
+                [
+                    new("id", "integer", IsPrimaryKey: true),
+                    new("name", "varchar"),
+                    new("email", "varchar"),
+                    new("age", "integer"),
+                    new("active", "boolean"),
+                ],
+                PrimaryKey: ["id"]),
+            new SqlTableSchema(
+                "orders",
+                [
+                    new("id", "integer", IsPrimaryKey: true),
+                    new(
+                        "user_id",
+                        "integer",
+                        References: withRelationship
+                            ? new SqlColumnReference("users", "id")
+                            : null),
+                    new("total", "decimal"),
+                    new("description", "varchar"),
+                ],
+                PrimaryKey: ["id"]));
+}


### PR DESCRIPTION
Cyqwel can parse and transform SQL, but callers currently lack a unified way to validate queries against semantic rules and application schemas. This adds an idiomatic .NET validation API that builds on the existing parser and dialect-neutral AST.

## Summary

- Add stable public result, diagnostic, option, catalog, foreign-key, and type-family models through `SqlValidator`.
- Wrap parser diagnostics and add strict trailing-comma handling plus opt-in semantic checks for `SELECT *`, aggregate grouping, `DISTINCT` ordering, and non-deterministic row limiting.
- Add scope-aware schema resolution for tables, columns, aliases, joins, derived tables, and recursive CTE projections.
- Add optional type checks for expressions, predicates, supported functions, DML assignments, scalar subqueries, and set operations.
- Add optional relationship checks for foreign-key metadata, ambiguous references, cartesian joins, and joins that bypass declared relationships.
- Document the API and organize focused coverage by syntax, semantic, schema, type, and reference validation.

Parser and strict-syntax findings include exact source locations. AST-derived diagnostics expose nullable locations so they can use node spans when the parser begins populating them.

## Testing

- 51 focused SQL validation tests
- Full Release suite: 757 tests passed