### PR TITLE
Add GitHub Source Link package

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.301" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
     <PackageVersion Include="Parlot" Version="1.5.8" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />

--- a/src/Cyqwel/Cyqwel.csproj
+++ b/src/Cyqwel/Cyqwel.csproj
@@ -15,6 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Include="Parlot" />
   </ItemGroup>
 


### PR DESCRIPTION
Enable source-level debugging for published Cyqwel packages by including GitHub Source Link metadata.

Adds the centrally managed `Microsoft.SourceLink.GitHub` dependency to the library project and marks it private so it does not flow to package consumers.