### PR TITLE
Complete fluent builder API coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,32 @@ var sql = query.ToSql(SqlDialects.PostgreSql);
 // WHERE u.age > @minimumAge ORDER BY u.name ASC LIMIT 10
 ```
 
-Builders are available for `SELECT`, set operations, `INSERT`, `UPDATE`, `DELETE`, `CASE`, and expressions.
+Builders cover every statement represented by the syntax tree, including advanced queries,
+data modification, and DDL. Query builders compose through their built syntax trees:
+
+```csharp
+var ranked = Sql.SelectItems(
+        new SelectItem(
+            Sql.Func("ROW_NUMBER").Over(
+                partitionBy: [Sql.Col("region")],
+                orderBy: [Sql.Order(Sql.Col("amount"), OrderDirection.Descending)]),
+            "position"))
+    .From("sales")
+    .With("active_regions", Sql.Select("id").From("regions").Build())
+    .Qualify(Sql.Col("position").LessThanOrEqualTo(Sql.Lit(3)))
+    .Build();
+
+var combined = ranked
+    .ToSql(SqlDialects.PostgreSql);
+```
+
+The fluent API supports recursive and materialized CTEs, `UNION` / `INTERSECT` /
+`EXCEPT`, `VALUES`, named and inline windows, `QUALIFY`, hierarchical queries,
+advanced joins, `EXPLAIN`, `MERGE`, `UPDATE FROM`, `DELETE USING`,
+`RETURNING INTO`, and all supported DDL statements.
+
+Builder helpers only expose forms that can be parsed by at least one built-in
+dialect, so generated builder SQL can round-trip through the syntax tree.
 
 ## Extend dialects
 

--- a/src/Cyqwel/Ast/Expressions.cs
+++ b/src/Cyqwel/Ast/Expressions.cs
@@ -151,6 +151,41 @@ public sealed record FunctionCallExpression(
         : this(new SqlIdentifier(name), arguments)
     {
     }
+
+    public FunctionCallExpression Distinct(bool value = true) => this with { IsDistinct = value };
+
+    public FunctionCallExpression FilterWhere(SqlExpression predicate) =>
+        this with
+        {
+            Filter = predicate ?? throw new ArgumentNullException(nameof(predicate)),
+        };
+
+    public FunctionCallExpression WithinGroupBy(params OrderByItem[] orderBy)
+    {
+        ArgumentNullException.ThrowIfNull(orderBy);
+        if (orderBy.Length == 0)
+        {
+            throw new ArgumentException("At least one ordering expression is required.", nameof(orderBy));
+        }
+
+        return this with { WithinGroup = orderBy };
+    }
+
+    public WindowExpression Over(
+        IReadOnlyList<SqlExpression>? partitionBy = null,
+        IReadOnlyList<OrderByItem>? orderBy = null,
+        WindowFrame? frame = null) =>
+        new(this, partitionBy, orderBy, frame);
+
+    public WindowExpression Over(string windowName) =>
+        new(this, WindowName: new SqlIdentifier(windowName));
+
+    public WindowExpression Over(
+        string windowName,
+        IReadOnlyList<SqlExpression>? partitionBy,
+        IReadOnlyList<OrderByItem>? orderBy = null,
+        WindowFrame? frame = null) =>
+        new(this, partitionBy, orderBy, frame, new SqlIdentifier(windowName));
 }
 
 public sealed record WindowExpression(

--- a/src/Cyqwel/Ast/SqlNode.cs
+++ b/src/Cyqwel/Ast/SqlNode.cs
@@ -55,20 +55,58 @@ public abstract record SqlExpression : SqlNode
     public BinaryExpression Subtract(SqlExpression right) => Binary(BinaryOperator.Subtract, right);
     public BinaryExpression Multiply(SqlExpression right) => Binary(BinaryOperator.Multiply, right);
     public BinaryExpression Divide(SqlExpression right) => Binary(BinaryOperator.Divide, right);
+    public BinaryExpression Modulo(SqlExpression right) => Binary(BinaryOperator.Modulo, right);
+    public BinaryExpression Concatenate(SqlExpression right) => Binary(BinaryOperator.Concatenate, right);
+    public BinaryExpression BitwiseAnd(SqlExpression right) => Binary(BinaryOperator.BitwiseAnd, right);
+    public BinaryExpression BitwiseOr(SqlExpression right) => Binary(BinaryOperator.BitwiseOr, right);
+    public BinaryExpression BitwiseXor(SqlExpression right) => Binary(BinaryOperator.BitwiseXor, right);
     public BinaryExpression Like(SqlExpression pattern) => Binary(BinaryOperator.Like, pattern);
+    public BinaryExpression NotLike(SqlExpression pattern) => Binary(BinaryOperator.NotLike, pattern);
     public BinaryExpression ILike(SqlExpression pattern) => Binary(BinaryOperator.ILike, pattern);
+    public BinaryExpression NotILike(SqlExpression pattern) => Binary(BinaryOperator.NotILike, pattern);
+    public UnaryExpression Positive() => new(UnaryOperator.Plus, this);
+    public UnaryExpression Negate() => new(UnaryOperator.Minus, this);
     public UnaryExpression Not() => new(UnaryOperator.Not, this);
+    public UnaryExpression BitwiseNot() => new(UnaryOperator.BitwiseNot, this);
+    public UnaryExpression Prior() => new(UnaryOperator.Prior, this);
+    public UnaryExpression ConnectByRoot() => new(UnaryOperator.ConnectByRoot, this);
     public IsNullExpression IsNull() => new(this, false);
     public IsNullExpression IsNotNull() => new(this, true);
+    public BooleanTestExpression IsTrue() => new(this, BooleanTestKind.True);
+    public BooleanTestExpression IsNotTrue() => new(this, BooleanTestKind.True, true);
+    public BooleanTestExpression IsFalse() => new(this, BooleanTestKind.False);
+    public BooleanTestExpression IsNotFalse() => new(this, BooleanTestKind.False, true);
+    public BooleanTestExpression IsUnknown() => new(this, BooleanTestKind.Unknown);
+    public BooleanTestExpression IsNotUnknown() => new(this, BooleanTestKind.Unknown, true);
+    public DistinctFromExpression IsDistinctFrom(SqlExpression right) => new(this, right);
+    public DistinctFromExpression IsNotDistinctFrom(SqlExpression right) => new(this, right, true);
     public BetweenExpression Between(SqlExpression lower, SqlExpression upper) => new(this, lower, upper, false);
     public BetweenExpression NotBetween(SqlExpression lower, SqlExpression upper) => new(this, lower, upper, true);
-    public InExpression In(params SqlExpression[] values) => new(this, values, null, false);
-    public InExpression NotIn(params SqlExpression[] values) => new(this, values, null, true);
+    public InExpression In(params SqlExpression[] values) =>
+        InValues(values, isNegated: false);
+    public InExpression NotIn(params SqlExpression[] values) =>
+        InValues(values, isNegated: true);
+    public InExpression In(SqlQuery query) =>
+        new(this, query ?? throw new ArgumentNullException(nameof(query)));
+    public InExpression NotIn(SqlQuery query) =>
+        new(this, query ?? throw new ArgumentNullException(nameof(query)), true);
+    public CollateExpression Collate(string collation) => new(this, new SqlIdentifier(collation));
 
     private BinaryExpression Binary(BinaryOperator @operator, SqlExpression right)
     {
         ArgumentNullException.ThrowIfNull(right);
         return new(this, @operator, right);
+    }
+
+    private InExpression InValues(SqlExpression[] values, bool isNegated)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+        if (values.Length == 0)
+        {
+            throw new ArgumentException("At least one IN value is required.", nameof(values));
+        }
+
+        return new InExpression(this, values, null, isNegated);
     }
 }
 

--- a/src/Cyqwel/Builders/DdlBuilders.cs
+++ b/src/Cyqwel/Builders/DdlBuilders.cs
@@ -1,0 +1,461 @@
+using Cyqwel.Ast;
+using Cyqwel.Dialects;
+using Cyqwel.Generation;
+
+namespace Cyqwel;
+
+public sealed class CreateTableBuilder
+{
+    private readonly TableName _name;
+    private readonly List<TableElement> _elements = [];
+    private bool _ifNotExists;
+    private bool _isTemporary;
+    private SqlQuery? _asQuery;
+
+    internal CreateTableBuilder(string name) => _name = new TableName(name);
+
+    public CreateTableBuilder IfNotExists(bool value = true)
+    {
+        _ifNotExists = value;
+        return this;
+    }
+
+    public CreateTableBuilder Temporary(bool value = true)
+    {
+        _isTemporary = value;
+        return this;
+    }
+
+    public CreateTableBuilder Add(TableElement element)
+    {
+        _elements.Add(element ?? throw new ArgumentNullException(nameof(element)));
+        return this;
+    }
+
+    public CreateTableBuilder Column(ColumnDefinition column) => Add(column);
+
+    public CreateTableBuilder Column(
+        string name,
+        string dataType,
+        params int[] dataTypeArguments) =>
+        Column(new ColumnDefinition(
+            new SqlIdentifier(name),
+            new SqlDataType(dataType, dataTypeArguments)));
+
+    public CreateTableBuilder Constraint(TableConstraint constraint) => Add(constraint);
+
+    public CreateTableBuilder As(SqlQuery query)
+    {
+        _asQuery = query ?? throw new ArgumentNullException(nameof(query));
+        return this;
+    }
+
+    public CreateTableStatement Build()
+    {
+        if (_elements.Count == 0 && _asQuery is null)
+        {
+            throw new InvalidOperationException("CREATE TABLE requires at least one element or an AS query.");
+        }
+
+        return new CreateTableStatement(
+            _name,
+            _elements.ToArray(),
+            _ifNotExists,
+            _isTemporary,
+            _asQuery);
+    }
+
+    public string ToSql(SqlDialect? dialect = null, SqlGenerationOptions? options = null) =>
+        Build().ToSql(dialect, options);
+}
+
+public sealed class AlterTableBuilder
+{
+    private readonly TableName _name;
+    private readonly List<AlterTableAction> _actions = [];
+
+    internal AlterTableBuilder(string name) => _name = new TableName(name);
+
+    public AlterTableBuilder Add(AlterTableAction action)
+    {
+        _actions.Add(action ?? throw new ArgumentNullException(nameof(action)));
+        return this;
+    }
+
+    public AlterTableBuilder AddColumn(ColumnDefinition column) =>
+        Add(new AddColumnAction(column));
+
+    public AlterTableBuilder AddColumn(
+        string name,
+        string dataType,
+        params int[] dataTypeArguments) =>
+        AddColumn(new ColumnDefinition(
+            new SqlIdentifier(name),
+            new SqlDataType(dataType, dataTypeArguments)));
+
+    public AlterTableBuilder DropColumn(
+        string column,
+        bool ifExists = false,
+        bool cascade = false) =>
+        Add(new DropColumnAction(new SqlIdentifier(column), ifExists, cascade));
+
+    public AlterTableBuilder AlterColumn(
+        string column,
+        SqlDataType? dataType = null,
+        Nullability nullability = Nullability.Unspecified,
+        SqlExpression? defaultValue = null,
+        bool dropDefault = false)
+    {
+        var operationCount =
+            (dataType is null ? 0 : 1)
+            + (nullability == Nullability.Unspecified ? 0 : 1)
+            + (defaultValue is null ? 0 : 1)
+            + (dropDefault ? 1 : 0);
+        if (operationCount != 1)
+        {
+            throw new ArgumentException("ALTER COLUMN requires exactly one operation.");
+        }
+
+        return Add(new AlterColumnAction(
+            new SqlIdentifier(column),
+            dataType,
+            nullability,
+            defaultValue,
+            dropDefault));
+    }
+
+    public AlterTableBuilder AddConstraint(TableConstraint constraint) =>
+        Add(new AddConstraintAction(constraint));
+
+    public AlterTableBuilder DropConstraint(
+        string constraint,
+        bool ifExists = false,
+        bool cascade = false) =>
+        Add(new DropConstraintAction(new SqlIdentifier(constraint), ifExists, cascade));
+
+    public AlterTableBuilder RenameColumn(string column, string newName) =>
+        Add(new RenameColumnAction(new SqlIdentifier(column), new SqlIdentifier(newName)));
+
+    public AlterTableBuilder RenameTo(string newName) =>
+        Add(new RenameTableAction(new SqlIdentifier(newName)));
+
+    public AlterTableStatement Build()
+    {
+        if (_actions.Count == 0)
+        {
+            throw new InvalidOperationException("ALTER TABLE requires at least one action.");
+        }
+
+        return new AlterTableStatement(_name, _actions.ToArray());
+    }
+
+    public string ToSql(SqlDialect? dialect = null, SqlGenerationOptions? options = null) =>
+        Build().ToSql(dialect, options);
+}
+
+public sealed class DropBuilder
+{
+    private readonly SchemaObjectKind _kind;
+    private readonly List<TableName> _names;
+    private bool _ifExists;
+    private bool _cascade;
+
+    internal DropBuilder(SchemaObjectKind kind, string name)
+    {
+        _kind = kind;
+        _names = [new TableName(name)];
+    }
+
+    public DropBuilder And(string name)
+    {
+        _names.Add(new TableName(name));
+        return this;
+    }
+
+    public DropBuilder IfExists(bool value = true)
+    {
+        _ifExists = value;
+        return this;
+    }
+
+    public DropBuilder Cascade(bool value = true)
+    {
+        _cascade = value;
+        return this;
+    }
+
+    public DropStatement Build() => new(_kind, _names.ToArray(), _ifExists, _cascade);
+
+    public string ToSql(SqlDialect? dialect = null, SqlGenerationOptions? options = null) =>
+        Build().ToSql(dialect, options);
+}
+
+public sealed class TruncateBuilder
+{
+    private readonly List<TableName> _tables;
+    private bool _restartIdentity;
+    private bool _cascade;
+
+    internal TruncateBuilder(string table) => _tables = [new TableName(table)];
+
+    public TruncateBuilder And(string table)
+    {
+        _tables.Add(new TableName(table));
+        return this;
+    }
+
+    public TruncateBuilder RestartIdentity(bool value = true)
+    {
+        _restartIdentity = value;
+        return this;
+    }
+
+    public TruncateBuilder Cascade(bool value = true)
+    {
+        _cascade = value;
+        return this;
+    }
+
+    public TruncateStatement Build() => new(_tables.ToArray(), _restartIdentity, _cascade);
+
+    public string ToSql(SqlDialect? dialect = null, SqlGenerationOptions? options = null) =>
+        Build().ToSql(dialect, options);
+}
+
+public sealed class CreateViewBuilder
+{
+    private readonly TableName _name;
+    private SqlQuery? _query;
+    private IReadOnlyList<SqlIdentifier>? _columns;
+    private bool _orReplace;
+    private bool _isTemporary;
+    private ViewSecurity? _security;
+
+    internal CreateViewBuilder(string name) => _name = new TableName(name);
+
+    public CreateViewBuilder As(SqlQuery query)
+    {
+        _query = query ?? throw new ArgumentNullException(nameof(query));
+        return this;
+    }
+
+    public CreateViewBuilder Columns(params string[] columns)
+    {
+        _columns = columns.Select(static column => new SqlIdentifier(column)).ToArray();
+        return this;
+    }
+
+    public CreateViewBuilder OrReplace(bool value = true)
+    {
+        _orReplace = value;
+        return this;
+    }
+
+    public CreateViewBuilder Temporary(bool value = true)
+    {
+        _isTemporary = value;
+        return this;
+    }
+
+    public CreateViewBuilder Security(ViewSecurity value)
+    {
+        _security = value;
+        return this;
+    }
+
+    public CreateViewStatement Build() =>
+        new(
+            _name,
+            _query ?? throw new InvalidOperationException("CREATE VIEW requires an AS query."),
+            _columns?.ToArray(),
+            _orReplace,
+            _isTemporary,
+            _security);
+
+    public string ToSql(SqlDialect? dialect = null, SqlGenerationOptions? options = null) =>
+        Build().ToSql(dialect, options);
+}
+
+public sealed class CreateIndexBuilder
+{
+    private readonly TableName _name;
+    private readonly TableName _table;
+    private readonly List<IndexColumn> _columns = [];
+    private bool _isUnique;
+    private bool _ifNotExists;
+    private SqlExpression? _where;
+
+    internal CreateIndexBuilder(string name, string table)
+    {
+        _name = new TableName(name);
+        _table = new TableName(table);
+    }
+
+    public CreateIndexBuilder Column(
+        SqlExpression expression,
+        OrderDirection direction = OrderDirection.Unspecified,
+        NullOrder nullOrder = NullOrder.Unspecified)
+    {
+        _columns.Add(new IndexColumn(
+            expression ?? throw new ArgumentNullException(nameof(expression)),
+            direction,
+            nullOrder));
+        return this;
+    }
+
+    public CreateIndexBuilder Column(
+        string column,
+        OrderDirection direction = OrderDirection.Unspecified,
+        NullOrder nullOrder = NullOrder.Unspecified) =>
+        Column(Sql.Col(column), direction, nullOrder);
+
+    public CreateIndexBuilder Unique(bool value = true)
+    {
+        _isUnique = value;
+        return this;
+    }
+
+    public CreateIndexBuilder IfNotExists(bool value = true)
+    {
+        _ifNotExists = value;
+        return this;
+    }
+
+    public CreateIndexBuilder Where(SqlExpression predicate)
+    {
+        _where = predicate ?? throw new ArgumentNullException(nameof(predicate));
+        return this;
+    }
+
+    public CreateIndexStatement Build()
+    {
+        if (_columns.Count == 0)
+        {
+            throw new InvalidOperationException("CREATE INDEX requires at least one column.");
+        }
+
+        return new CreateIndexStatement(
+            _name,
+            _table,
+            _columns.ToArray(),
+            _isUnique,
+            _ifNotExists,
+            _where);
+    }
+
+    public string ToSql(SqlDialect? dialect = null, SqlGenerationOptions? options = null) =>
+        Build().ToSql(dialect, options);
+}
+
+public sealed class CreateSequenceBuilder
+{
+    private readonly TableName _name;
+    private SequenceOptions _options = new();
+    private bool _ifNotExists;
+
+    internal CreateSequenceBuilder(string name) => _name = new TableName(name);
+
+    public CreateSequenceBuilder IfNotExists(bool value = true)
+    {
+        _ifNotExists = value;
+        return this;
+    }
+
+    public CreateSequenceBuilder StartWith(object value)
+    {
+        _options = _options with { StartWith = Sql.Coerce(value) };
+        return this;
+    }
+
+    public CreateSequenceBuilder IncrementBy(object value)
+    {
+        _options = _options with { IncrementBy = Sql.Coerce(value) };
+        return this;
+    }
+
+    public CreateSequenceBuilder MinValue(object value)
+    {
+        _options = _options with { MinimumValue = Sql.Coerce(value) };
+        return this;
+    }
+
+    public CreateSequenceBuilder MaxValue(object value)
+    {
+        _options = _options with { MaximumValue = Sql.Coerce(value) };
+        return this;
+    }
+
+    public CreateSequenceBuilder Cache(object value)
+    {
+        _options = _options with { Cache = Sql.Coerce(value) };
+        return this;
+    }
+
+    public CreateSequenceBuilder Cycle(bool value = true)
+    {
+        _options = _options with { Cycle = value };
+        return this;
+    }
+
+    public CreateSequenceStatement Build() => new(_name, _options, _ifNotExists);
+
+    public string ToSql(SqlDialect? dialect = null, SqlGenerationOptions? options = null) =>
+        Build().ToSql(dialect, options);
+}
+
+public sealed class AlterSequenceBuilder
+{
+    private readonly TableName _name;
+    private SequenceOptions _options = new();
+
+    internal AlterSequenceBuilder(string name) => _name = new TableName(name);
+
+    public AlterSequenceBuilder StartWith(object value)
+    {
+        _options = _options with { StartWith = Sql.Coerce(value) };
+        return this;
+    }
+
+    public AlterSequenceBuilder IncrementBy(object value)
+    {
+        _options = _options with { IncrementBy = Sql.Coerce(value) };
+        return this;
+    }
+
+    public AlterSequenceBuilder MinValue(object value)
+    {
+        _options = _options with { MinimumValue = Sql.Coerce(value) };
+        return this;
+    }
+
+    public AlterSequenceBuilder MaxValue(object value)
+    {
+        _options = _options with { MaximumValue = Sql.Coerce(value) };
+        return this;
+    }
+
+    public AlterSequenceBuilder Cache(object value)
+    {
+        _options = _options with { Cache = Sql.Coerce(value) };
+        return this;
+    }
+
+    public AlterSequenceBuilder Cycle(bool value = true)
+    {
+        _options = _options with { Cycle = value };
+        return this;
+    }
+
+    public AlterSequenceStatement Build()
+    {
+        if (_options == new SequenceOptions())
+        {
+            throw new InvalidOperationException("ALTER SEQUENCE requires at least one option.");
+        }
+
+        return new AlterSequenceStatement(_name, _options);
+    }
+
+    public string ToSql(SqlDialect? dialect = null, SqlGenerationOptions? options = null) =>
+        Build().ToSql(dialect, options);
+}

--- a/src/Cyqwel/Builders/MutationBuilders.cs
+++ b/src/Cyqwel/Builders/MutationBuilders.cs
@@ -11,11 +11,24 @@ public sealed class InsertBuilder
     private readonly List<IReadOnlyList<SqlExpression>> _values = [];
     private SqlQuery? _source;
     private IReadOnlyList<SqlExpression>? _returning;
+    private IReadOnlyList<SqlExpression>? _returningInto;
 
     internal InsertBuilder(string table) => _target = new TableName(table);
 
     public InsertBuilder Columns(params string[] columns)
     {
+        if (columns.Length == 0)
+        {
+            throw new ArgumentException("At least one column is required.", nameof(columns));
+        }
+
+        if (_values.Any(row => row.Count != columns.Length))
+        {
+            throw new ArgumentException(
+                "The number of columns must match every existing VALUES row.",
+                nameof(columns));
+        }
+
         _columns = columns.Select(static column => new SqlIdentifier(column)).ToArray();
         return this;
     }
@@ -23,9 +36,13 @@ public sealed class InsertBuilder
     public InsertBuilder Values(params object?[] values)
     {
         if (_source is not null) throw new InvalidOperationException("An INSERT cannot contain both VALUES and a source query.");
-        if (_columns is not null && values.Length != _columns.Count)
+        if (values.Length == 0) throw new ArgumentException("At least one value is required.", nameof(values));
+        var expectedCount = _columns?.Count ?? (_values.Count == 0 ? null : _values[0].Count);
+        if (expectedCount.HasValue && values.Length != expectedCount.Value)
         {
-            throw new ArgumentException("The number of values must match the number of columns.", nameof(values));
+            throw new ArgumentException(
+                "Every VALUES row must match the established column count.",
+                nameof(values));
         }
 
         _values.Add(values.Select(Sql.Coerce).ToArray());
@@ -45,12 +62,20 @@ public sealed class InsertBuilder
         return this;
     }
 
+    public InsertBuilder ReturningInto(params SqlExpression[] expressions)
+    {
+        _returningInto = expressions;
+        return this;
+    }
+
     public InsertStatement Build()
     {
         if (_source is null && _values.Count == 0)
         {
             throw new InvalidOperationException("An INSERT requires at least one VALUES row or a source query.");
         }
+
+        MutationBuilderValidation.ValidateReturningInto(_returning, _returningInto);
 
         return new InsertStatement(
             _target,
@@ -59,7 +84,8 @@ public sealed class InsertBuilder
                 ? null
                 : _values.Select(static row => (IReadOnlyList<SqlExpression>)row.ToArray()).ToArray(),
             _source,
-            _returning?.ToArray());
+            _returning?.ToArray(),
+            _returningInto?.ToArray());
     }
 
     public string ToSql(SqlDialect? dialect = null, SqlGenerationOptions? options = null) =>
@@ -72,6 +98,8 @@ public sealed class UpdateBuilder
     private readonly List<Assignment> _assignments = [];
     private SqlExpression? _where;
     private IReadOnlyList<SqlExpression>? _returning;
+    private IReadOnlyList<SqlExpression>? _returningInto;
+    private TableSource? _from;
 
     internal UpdateBuilder(string table, string? alias) => _target = new NamedTable(table, alias);
 
@@ -87,16 +115,44 @@ public sealed class UpdateBuilder
         return this;
     }
 
+    public UpdateBuilder From(string table, string? alias = null) =>
+        From(new NamedTable(table, alias));
+
+    public UpdateBuilder From(SqlQuery query, string alias) =>
+        From(new DerivedTable(
+            query ?? throw new ArgumentNullException(nameof(query)),
+            new SqlIdentifier(alias)));
+
+    public UpdateBuilder From(TableSource source)
+    {
+        _from = source ?? throw new ArgumentNullException(nameof(source));
+        return this;
+    }
+
     public UpdateBuilder Returning(params SqlExpression[] expressions)
     {
         _returning = expressions;
         return this;
     }
 
+    public UpdateBuilder ReturningInto(params SqlExpression[] expressions)
+    {
+        _returningInto = expressions;
+        return this;
+    }
+
     public UpdateStatement Build()
     {
         if (_assignments.Count == 0) throw new InvalidOperationException("An UPDATE requires at least one assignment.");
-        return new UpdateStatement(_target, _assignments.ToArray(), _where, _returning?.ToArray());
+        MutationBuilderValidation.ValidateReturningInto(_returning, _returningInto);
+
+        return new UpdateStatement(
+            _target,
+            _assignments.ToArray(),
+            _where,
+            _returning?.ToArray(),
+            _returningInto?.ToArray(),
+            _from);
     }
 
     public string ToSql(SqlDialect? dialect = null, SqlGenerationOptions? options = null) =>
@@ -108,6 +164,8 @@ public sealed class DeleteBuilder
     private readonly NamedTable _target;
     private SqlExpression? _where;
     private IReadOnlyList<SqlExpression>? _returning;
+    private IReadOnlyList<SqlExpression>? _returningInto;
+    private TableSource? _using;
 
     internal DeleteBuilder(string table, string? alias) => _target = new NamedTable(table, alias);
 
@@ -117,16 +175,218 @@ public sealed class DeleteBuilder
         return this;
     }
 
+    public DeleteBuilder Using(string table, string? alias = null) =>
+        Using(new NamedTable(table, alias));
+
+    public DeleteBuilder Using(SqlQuery query, string alias) =>
+        Using(new DerivedTable(
+            query ?? throw new ArgumentNullException(nameof(query)),
+            new SqlIdentifier(alias)));
+
+    public DeleteBuilder Using(TableSource source)
+    {
+        _using = source ?? throw new ArgumentNullException(nameof(source));
+        return this;
+    }
+
     public DeleteBuilder Returning(params SqlExpression[] expressions)
     {
         _returning = expressions;
         return this;
     }
 
-    public DeleteStatement Build() => new(_target, _where, _returning?.ToArray());
+    public DeleteBuilder ReturningInto(params SqlExpression[] expressions)
+    {
+        _returningInto = expressions;
+        return this;
+    }
+
+    public DeleteStatement Build()
+    {
+        MutationBuilderValidation.ValidateReturningInto(_returning, _returningInto);
+
+        return new DeleteStatement(
+            _target,
+            _where,
+            _returning?.ToArray(),
+            _returningInto?.ToArray(),
+            _using);
+    }
 
     public string ToSql(SqlDialect? dialect = null, SqlGenerationOptions? options = null) =>
         Build().ToSql(dialect, options);
+}
+
+public sealed class MergeBuilder
+{
+    private readonly NamedTable _target;
+    private TableSource? _source;
+    private SqlExpression? _condition;
+    private readonly List<MergeWhenClause> _whenClauses = [];
+    private IReadOnlyList<SqlExpression>? _returning;
+    private IReadOnlyList<SqlExpression>? _returningInto;
+
+    internal MergeBuilder(string table, string? alias) => _target = new NamedTable(table, alias);
+
+    public MergeBuilder Using(string table, string? alias = null) =>
+        Using(new NamedTable(table, alias));
+
+    public MergeBuilder Using(SqlQuery query, string alias) =>
+        Using(new DerivedTable(
+            query ?? throw new ArgumentNullException(nameof(query)),
+            new SqlIdentifier(alias)));
+
+    public MergeBuilder Using(TableSource source)
+    {
+        _source = source ?? throw new ArgumentNullException(nameof(source));
+        return this;
+    }
+
+    public MergeBuilder On(SqlExpression condition)
+    {
+        _condition = condition ?? throw new ArgumentNullException(nameof(condition));
+        return this;
+    }
+
+    public MergeBuilder WhenMatchedUpdate(params Assignment[] assignments) =>
+        AddUpdate(MergeMatchKind.Matched, condition: null, assignments);
+
+    public MergeBuilder WhenMatchedUpdate(
+        SqlExpression condition,
+        params Assignment[] assignments) =>
+        AddUpdate(MergeMatchKind.Matched, condition, assignments);
+
+    public MergeBuilder WhenMatchedUpdate(
+        SqlExpression? condition,
+        SqlExpression deleteWhere,
+        params Assignment[] assignments) =>
+        AddUpdate(MergeMatchKind.Matched, condition, assignments, deleteWhere);
+
+    public MergeBuilder WhenNotMatchedBySourceUpdate(params Assignment[] assignments) =>
+        AddUpdate(MergeMatchKind.NotMatchedBySource, condition: null, assignments);
+
+    public MergeBuilder WhenNotMatchedBySourceUpdate(
+        SqlExpression condition,
+        params Assignment[] assignments) =>
+        AddUpdate(MergeMatchKind.NotMatchedBySource, condition, assignments);
+
+    public MergeBuilder WhenNotMatchedInsert(
+        IReadOnlyList<string>? columns,
+        params object?[] values) =>
+        AddInsert(condition: null, columns, values);
+
+    public MergeBuilder WhenNotMatchedInsert(
+        SqlExpression condition,
+        IReadOnlyList<string>? columns,
+        params object?[] values) =>
+        AddInsert(condition, columns, values);
+
+    public MergeBuilder WhenMatchedDelete(SqlExpression? condition = null) =>
+        AddDelete(MergeMatchKind.Matched, condition);
+
+    public MergeBuilder WhenNotMatchedBySourceDelete(SqlExpression? condition = null) =>
+        AddDelete(MergeMatchKind.NotMatchedBySource, condition);
+
+    public MergeBuilder Returning(params SqlExpression[] expressions)
+    {
+        _returning = expressions;
+        return this;
+    }
+
+    public MergeBuilder ReturningInto(params SqlExpression[] expressions)
+    {
+        _returningInto = expressions;
+        return this;
+    }
+
+    public MergeStatement Build()
+    {
+        if (_source is null) throw new InvalidOperationException("A MERGE requires a source.");
+        if (_condition is null) throw new InvalidOperationException("A MERGE requires an ON condition.");
+        if (_whenClauses.Count == 0) throw new InvalidOperationException("A MERGE requires at least one WHEN clause.");
+        MutationBuilderValidation.ValidateReturningInto(_returning, _returningInto);
+
+        return new MergeStatement(
+            _target,
+            _source,
+            _condition,
+            _whenClauses.ToArray(),
+            _returning?.ToArray(),
+            _returningInto?.ToArray());
+    }
+
+    public string ToSql(SqlDialect? dialect = null, SqlGenerationOptions? options = null) =>
+        Build().ToSql(dialect, options);
+
+    private MergeBuilder AddUpdate(
+        MergeMatchKind matchKind,
+        SqlExpression? condition,
+        IReadOnlyList<Assignment> assignments,
+        SqlExpression? deleteWhere = null)
+    {
+        ArgumentNullException.ThrowIfNull(assignments);
+        if (assignments.Count == 0)
+        {
+            throw new ArgumentException("At least one assignment is required.", nameof(assignments));
+        }
+
+        _whenClauses.Add(new MergeWhenClause(
+            matchKind,
+            new MergeUpdateAction(assignments.ToArray(), deleteWhere),
+            condition));
+        return this;
+    }
+
+    private MergeBuilder AddInsert(
+        SqlExpression? condition,
+        IReadOnlyList<string>? columns,
+        IReadOnlyList<object?> values)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+        if (values.Count == 0)
+        {
+            throw new ArgumentException("At least one value is required.", nameof(values));
+        }
+
+        if (columns is { Count: > 0 } && columns.Count != values.Count)
+        {
+            throw new ArgumentException("The number of values must match the number of columns.", nameof(values));
+        }
+
+        _whenClauses.Add(new MergeWhenClause(
+            MergeMatchKind.NotMatched,
+            new MergeInsertAction(
+                columns?.Select(static column => new SqlIdentifier(column)).ToArray(),
+                values.Select(Sql.Coerce).ToArray()),
+            condition));
+        return this;
+    }
+
+    private MergeBuilder AddDelete(MergeMatchKind matchKind, SqlExpression? condition)
+    {
+        _whenClauses.Add(new MergeWhenClause(matchKind, new MergeDeleteAction(), condition));
+        return this;
+    }
+}
+
+internal static class MutationBuilderValidation
+{
+    internal static void ValidateReturningInto(
+        IReadOnlyList<SqlExpression>? returning,
+        IReadOnlyList<SqlExpression>? returningInto)
+    {
+        if (returningInto is not { Count: > 0 }) return;
+        if (returning is not { Count: > 0 })
+        {
+            throw new InvalidOperationException("RETURNING INTO requires RETURNING expressions.");
+        }
+
+        if (returning.Count != returningInto.Count)
+        {
+            throw new InvalidOperationException(
+                "RETURNING and INTO must contain the same number of expressions.");
+        }
+    }
 }
 
 public sealed class CaseBuilder

--- a/src/Cyqwel/Builders/QueryBuilders.cs
+++ b/src/Cyqwel/Builders/QueryBuilders.cs
@@ -1,0 +1,157 @@
+using Cyqwel.Ast;
+using Cyqwel.Dialects;
+using Cyqwel.Generation;
+
+namespace Cyqwel;
+
+public sealed class ValuesBuilder
+{
+    private ValuesStatement _statement;
+
+    internal ValuesBuilder(IReadOnlyList<SqlExpression> row)
+    {
+        ArgumentNullException.ThrowIfNull(row);
+        if (row.Count == 0) throw new ArgumentException("At least one value is required.", nameof(row));
+        _statement = new ValuesStatement([row]);
+    }
+
+    public ValuesBuilder Row(params object?[] values)
+    {
+        if (values.Length == 0) throw new ArgumentException("At least one value is required.", nameof(values));
+        if (values.Length != _statement.Rows[0].Count)
+        {
+            throw new ArgumentException(
+                "Every VALUES row must contain the same number of values.",
+                nameof(values));
+        }
+
+        var rows = _statement.Rows.ToList();
+        rows.Add(values.Select(Sql.Coerce).ToArray());
+        _statement = _statement with { Rows = rows };
+        return this;
+    }
+
+    public ValuesBuilder OrderBy(
+        SqlExpression expression,
+        OrderDirection direction = OrderDirection.Ascending,
+        NullOrder nullOrder = NullOrder.Unspecified)
+    {
+        _statement = _statement with { OrderBy = [new OrderByItem(expression, direction, nullOrder)] };
+        return this;
+    }
+
+    public ValuesBuilder ThenBy(
+        SqlExpression expression,
+        OrderDirection direction = OrderDirection.Ascending,
+        NullOrder nullOrder = NullOrder.Unspecified)
+    {
+        var items = _statement.OrderBy?.ToList() ?? [];
+        items.Add(new OrderByItem(expression, direction, nullOrder));
+        _statement = _statement with { OrderBy = items };
+        return this;
+    }
+
+    public ValuesBuilder Limit(long value) => Limit(Sql.Lit(value));
+
+    public ValuesBuilder Limit(SqlExpression value)
+    {
+        _statement = _statement with
+        {
+            Limit = value ?? throw new ArgumentNullException(nameof(value)),
+        };
+        return this;
+    }
+
+    public ValuesBuilder Offset(long value) => Offset(Sql.Lit(value));
+
+    public ValuesBuilder Offset(SqlExpression value)
+    {
+        _statement = _statement with
+        {
+            Offset = value ?? throw new ArgumentNullException(nameof(value)),
+        };
+        return this;
+    }
+
+    public ValuesBuilder With(string name, SqlQuery query, params string[] columns)
+        => With(name, query, CteMaterialization.Unspecified, columns);
+
+    public ValuesBuilder With(
+        string name,
+        SqlQuery query,
+        CteMaterialization materialization,
+        params string[] columns)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        var expressions = _statement.CommonTableExpressions?.ToList() ?? [];
+        expressions.Add(new CommonTableExpression(
+            new SqlIdentifier(name),
+            query,
+            columns.Length == 0
+                ? null
+                : columns.Select(static column => new SqlIdentifier(column)).ToArray(),
+            materialization));
+        _statement = _statement with { CommonTableExpressions = expressions };
+        return this;
+    }
+
+    public ValuesBuilder Recursive(bool value = true)
+    {
+        _statement = _statement with { IsRecursive = value };
+        return this;
+    }
+
+    public SetQueryBuilder Union(SqlQuery right, bool all = false) =>
+        new(new SetOperationStatement(Build(), SetOperator.Union, right, all));
+
+    public SetQueryBuilder Union(SelectBuilder right, bool all = false) =>
+        Union(right?.Build() ?? throw new ArgumentNullException(nameof(right)), all);
+
+    public SetQueryBuilder Intersect(SqlQuery right, bool all = false) =>
+        new(new SetOperationStatement(Build(), SetOperator.Intersect, right, all));
+
+    public SetQueryBuilder Intersect(SelectBuilder right, bool all = false) =>
+        Intersect(right?.Build() ?? throw new ArgumentNullException(nameof(right)), all);
+
+    public SetQueryBuilder Except(SqlQuery right, bool all = false) =>
+        new(new SetOperationStatement(Build(), SetOperator.Except, right, all));
+
+    public SetQueryBuilder Except(SelectBuilder right, bool all = false) =>
+        Except(right?.Build() ?? throw new ArgumentNullException(nameof(right)), all);
+
+    public ExplainBuilder Explain(bool analyze = false) => new(Build(), analyze);
+
+    public ValuesStatement Build() => _statement;
+
+    public string ToSql(SqlDialect? dialect = null, SqlGenerationOptions? options = null) =>
+        Build().ToSql(dialect, options);
+}
+
+public sealed class ExplainBuilder
+{
+    private ExplainStatement _statement;
+
+    internal ExplainBuilder(SqlQuery query, bool analyze = false)
+    {
+        _statement = new ExplainStatement(
+            query ?? throw new ArgumentNullException(nameof(query)),
+            analyze);
+    }
+
+    public ExplainBuilder Analyze(bool value = true)
+    {
+        _statement = _statement with { Analyze = value };
+        return this;
+    }
+
+    public ExplainBuilder Parenthesized(bool value = true)
+    {
+        _statement = _statement with { IsQueryParenthesized = value };
+        return this;
+    }
+
+    public ExplainStatement Build() => _statement;
+
+    public string ToSql(SqlDialect? dialect = null, SqlGenerationOptions? options = null) =>
+        Build().ToSql(dialect, options);
+}

--- a/src/Cyqwel/Builders/SelectBuilder.cs
+++ b/src/Cyqwel/Builders/SelectBuilder.cs
@@ -27,8 +27,15 @@ public sealed class SelectBuilder
         return this;
     }
 
+    public SelectBuilder From(TableSource source)
+    {
+        _statement = _statement with { From = source ?? throw new ArgumentNullException(nameof(source)) };
+        return this;
+    }
+
     public SelectBuilder From(SqlQuery query, string alias)
     {
+        ArgumentNullException.ThrowIfNull(query);
         _statement = _statement with { From = new DerivedTable(query, new SqlIdentifier(alias)) };
         return this;
     }
@@ -47,6 +54,64 @@ public sealed class SelectBuilder
 
     public SelectBuilder CrossJoin(string table, string? alias = null) =>
         AddJoin(JoinKind.Cross, new NamedTable(table, alias), null);
+
+    public SelectBuilder Join(
+        TableSource source,
+        SqlExpression condition,
+        JoinKind kind = JoinKind.Inner) =>
+        AddJoin(kind, source, condition);
+
+    public SelectBuilder Join(
+        SqlQuery query,
+        string alias,
+        SqlExpression condition,
+        JoinKind kind = JoinKind.Inner) =>
+        AddJoin(
+            kind,
+            new DerivedTable(
+                query ?? throw new ArgumentNullException(nameof(query)),
+                new SqlIdentifier(alias)),
+            condition);
+
+    public SelectBuilder JoinUsing(
+        string table,
+        IReadOnlyList<string> columns,
+        string? alias = null,
+        JoinKind kind = JoinKind.Inner) =>
+        JoinUsing(new NamedTable(table, alias), columns, kind);
+
+    public SelectBuilder JoinUsing(
+        TableSource source,
+        IReadOnlyList<string> columns,
+        JoinKind kind = JoinKind.Inner)
+    {
+        ArgumentNullException.ThrowIfNull(columns);
+        if (columns.Count == 0)
+        {
+            throw new ArgumentException("At least one USING column is required.", nameof(columns));
+        }
+
+        return AddJoin(
+            kind,
+            source,
+            condition: null,
+            usingColumns: columns.Select(static column => new SqlIdentifier(column)).ToArray());
+    }
+
+    public SelectBuilder NaturalJoin(
+        string table,
+        string? alias = null,
+        JoinKind kind = JoinKind.Inner) =>
+        NaturalJoin(new NamedTable(table, alias), kind);
+
+    public SelectBuilder NaturalJoin(TableSource source, JoinKind kind = JoinKind.Inner) =>
+        AddJoin(kind, source, condition: null, isNatural: true);
+
+    public SelectBuilder CommaJoin(string table, string? alias = null) =>
+        CommaJoin(new NamedTable(table, alias));
+
+    public SelectBuilder CommaJoin(TableSource source) =>
+        AddJoin(JoinKind.Cross, source, condition: null, syntax: JoinSyntax.Comma);
 
     public SelectBuilder Where(SqlExpression predicate)
     {
@@ -102,7 +167,15 @@ public sealed class SelectBuilder
 
     public SelectBuilder Limit(SqlExpression value)
     {
-        _statement = _statement with { Limit = value ?? throw new ArgumentNullException(nameof(value)) };
+        if (_statement.Top is not null && (_statement.IsTopPercent || _statement.WithTies))
+        {
+            throw new InvalidOperationException("LIMIT cannot be combined with TOP PERCENT or WITH TIES.");
+        }
+
+        _statement = _statement with
+        {
+            Limit = value ?? throw new ArgumentNullException(nameof(value)),
+        };
         return this;
     }
 
@@ -110,6 +183,11 @@ public sealed class SelectBuilder
 
     public SelectBuilder Offset(SqlExpression value)
     {
+        if (_statement.Top is not null && (_statement.IsTopPercent || _statement.WithTies))
+        {
+            throw new InvalidOperationException("OFFSET cannot be combined with TOP PERCENT or WITH TIES.");
+        }
+
         _statement = _statement with { Offset = value ?? throw new ArgumentNullException(nameof(value)) };
         return this;
     }
@@ -117,48 +195,178 @@ public sealed class SelectBuilder
     public SelectBuilder Top(long value) => Top(Sql.Lit(value));
 
     public SelectBuilder Top(SqlExpression value)
+        => Top(value, percent: false, withTies: false);
+
+    public SelectBuilder Top(long value, bool percent, bool withTies = false) =>
+        Top(Sql.Lit(value), percent, withTies);
+
+    public SelectBuilder Top(SqlExpression value, bool percent, bool withTies = false)
     {
-        _statement = _statement with { Top = value ?? throw new ArgumentNullException(nameof(value)) };
+        if ((percent || withTies) && (_statement.Limit is not null || _statement.Offset is not null))
+        {
+            throw new InvalidOperationException(
+                "TOP PERCENT or WITH TIES cannot be combined with LIMIT or OFFSET.");
+        }
+
+        _statement = _statement with
+        {
+            Top = value ?? throw new ArgumentNullException(nameof(value)),
+            IsTopPercent = percent,
+            WithTies = withTies,
+        };
         return this;
     }
 
     public SelectBuilder With(string name, SqlQuery query, params string[] columns)
+        => With(name, query, CteMaterialization.Unspecified, columns);
+
+    public SelectBuilder With(
+        string name,
+        SqlQuery query,
+        CteMaterialization materialization,
+        params string[] columns)
     {
+        ArgumentNullException.ThrowIfNull(query);
         var expressions = _statement.CommonTableExpressions?.ToList() ?? [];
         expressions.Add(new CommonTableExpression(
             new SqlIdentifier(name),
             query,
             columns.Length == 0
                 ? null
-                : columns.Select(static column => new SqlIdentifier(column)).ToArray()));
+                : columns.Select(static column => new SqlIdentifier(column)).ToArray(),
+            materialization));
         _statement = _statement with { CommonTableExpressions = expressions };
         return this;
     }
 
+    public SelectBuilder Recursive(bool value = true)
+    {
+        _statement = _statement with { IsRecursive = value };
+        return this;
+    }
+
+    public SelectBuilder Window(WindowDefinition definition)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        var windows = _statement.Windows?.ToList() ?? [];
+        windows.Add(definition);
+        _statement = _statement with { Windows = windows };
+        return this;
+    }
+
+    public SelectBuilder Window(
+        string name,
+        string? baseWindow = null,
+        IReadOnlyList<SqlExpression>? partitionBy = null,
+        IReadOnlyList<OrderByItem>? orderBy = null,
+        WindowFrame? frame = null) =>
+        Window(new WindowDefinition(
+            new SqlIdentifier(name),
+            baseWindow is null ? null : new SqlIdentifier(baseWindow),
+            partitionBy,
+            orderBy,
+            frame));
+
+    public SelectBuilder Qualify(SqlExpression predicate)
+    {
+        _statement = _statement with
+        {
+            Qualify = predicate ?? throw new ArgumentNullException(nameof(predicate)),
+        };
+        return this;
+    }
+
+    public SelectBuilder ConnectBy(
+        SqlExpression condition,
+        SqlExpression? startWith = null,
+        bool noCycle = false)
+    {
+        _statement = _statement with
+        {
+            ConnectBy = new ConnectByClause(
+                condition ?? throw new ArgumentNullException(nameof(condition)),
+                startWith,
+                noCycle),
+        };
+        return this;
+    }
+
+    public SelectBuilder OrderSiblingsBy(
+        SqlExpression expression,
+        OrderDirection direction = OrderDirection.Ascending,
+        NullOrder nullOrder = NullOrder.Unspecified)
+    {
+        _statement = _statement with
+        {
+            OrderBy = [new OrderByItem(expression, direction, nullOrder)],
+            OrderSiblings = true,
+        };
+        return this;
+    }
+
     public SetQueryBuilder Union(SelectBuilder right, bool all = false) =>
-        new(new SetOperationStatement(Build(), SetOperator.Union, right.Build(), all));
+        Union(right?.Build() ?? throw new ArgumentNullException(nameof(right)), all);
+
+    public SetQueryBuilder Union(SqlQuery right, bool all = false) =>
+        new(new SetOperationStatement(Build(), SetOperator.Union, right, all));
 
     public SetQueryBuilder Intersect(SelectBuilder right, bool all = false) =>
-        new(new SetOperationStatement(Build(), SetOperator.Intersect, right.Build(), all));
+        Intersect(right?.Build() ?? throw new ArgumentNullException(nameof(right)), all);
+
+    public SetQueryBuilder Intersect(SqlQuery right, bool all = false) =>
+        new(new SetOperationStatement(Build(), SetOperator.Intersect, right, all));
 
     public SetQueryBuilder Except(SelectBuilder right, bool all = false) =>
-        new(new SetOperationStatement(Build(), SetOperator.Except, right.Build(), all));
+        Except(right?.Build() ?? throw new ArgumentNullException(nameof(right)), all);
 
-    public SelectStatement Build() => _statement;
+    public SetQueryBuilder Except(SqlQuery right, bool all = false) =>
+        new(new SetOperationStatement(Build(), SetOperator.Except, right, all));
+
+    public ExplainBuilder Explain(bool analyze = false) => new(Build(), analyze);
+
+    public SelectStatement Build()
+    {
+        if (_statement.WithTies && _statement.OrderBy is not { Count: > 0 })
+        {
+            throw new InvalidOperationException("TOP WITH TIES requires ORDER BY.");
+        }
+
+        return _statement;
+    }
 
     public string ToSql(SqlDialect? dialect = null, SqlGenerationOptions? options = null) =>
         Build().ToSql(dialect, options);
 
-    private SelectBuilder AddJoin(JoinKind kind, TableSource right, SqlExpression? condition)
+    private SelectBuilder AddJoin(
+        JoinKind kind,
+        TableSource right,
+        SqlExpression? condition,
+        JoinSyntax syntax = JoinSyntax.Explicit,
+        IReadOnlyList<SqlIdentifier>? usingColumns = null,
+        bool isNatural = false)
     {
+        ArgumentNullException.ThrowIfNull(right);
         if (_statement.From is null)
         {
             throw new InvalidOperationException("FROM must be specified before adding a join.");
         }
 
+        if (kind == JoinKind.Cross && syntax == JoinSyntax.Explicit
+            && (condition is not null || usingColumns is { Count: > 0 } || isNatural))
+        {
+            throw new ArgumentException("A CROSS JOIN cannot have ON, USING, or NATURAL modifiers.", nameof(kind));
+        }
+
         _statement = _statement with
         {
-            From = new JoinTable(_statement.From, right, kind, condition),
+            From = new JoinTable(
+                _statement.From,
+                right,
+                kind,
+                condition,
+                syntax,
+                usingColumns,
+                isNatural),
         };
         return this;
     }
@@ -171,8 +379,29 @@ public sealed class SetQueryBuilder
     internal SetQueryBuilder(SetOperationStatement statement) => _statement = statement;
 
     public SetQueryBuilder Union(SelectBuilder right, bool all = false)
+        => Union(right?.Build() ?? throw new ArgumentNullException(nameof(right)), all);
+
+    public SetQueryBuilder Union(SqlQuery right, bool all = false)
     {
-        _statement = new SetOperationStatement(_statement, SetOperator.Union, right.Build(), all);
+        AddOperation(SetOperator.Union, right, all);
+        return this;
+    }
+
+    public SetQueryBuilder Intersect(SelectBuilder right, bool all = false)
+        => Intersect(right?.Build() ?? throw new ArgumentNullException(nameof(right)), all);
+
+    public SetQueryBuilder Intersect(SqlQuery right, bool all = false)
+    {
+        AddOperation(SetOperator.Intersect, right, all);
+        return this;
+    }
+
+    public SetQueryBuilder Except(SelectBuilder right, bool all = false)
+        => Except(right?.Build() ?? throw new ArgumentNullException(nameof(right)), all);
+
+    public SetQueryBuilder Except(SqlQuery right, bool all = false)
+    {
+        AddOperation(SetOperator.Except, right, all);
         return this;
     }
 
@@ -184,20 +413,79 @@ public sealed class SetQueryBuilder
         return this;
     }
 
-    public SetQueryBuilder Limit(long value)
+    public SetQueryBuilder ThenBy(
+        SqlExpression expression,
+        OrderDirection direction = OrderDirection.Ascending,
+        NullOrder nullOrder = NullOrder.Unspecified)
     {
-        _statement = _statement with { Limit = Sql.Lit(value) };
+        var items = _statement.OrderBy?.ToList() ?? [];
+        items.Add(new OrderByItem(expression, direction, nullOrder));
+        _statement = _statement with { OrderBy = items };
+        return this;
+    }
+
+    public SetQueryBuilder Limit(long value)
+        => Limit(Sql.Lit(value));
+
+    public SetQueryBuilder Limit(SqlExpression value)
+    {
+        _statement = _statement with
+        {
+            Limit = value ?? throw new ArgumentNullException(nameof(value)),
+        };
         return this;
     }
 
     public SetQueryBuilder Offset(long value)
+        => Offset(Sql.Lit(value));
+
+    public SetQueryBuilder Offset(SqlExpression value)
     {
-        _statement = _statement with { Offset = Sql.Lit(value) };
+        _statement = _statement with
+        {
+            Offset = value ?? throw new ArgumentNullException(nameof(value)),
+        };
         return this;
     }
+
+    public SetQueryBuilder With(string name, SqlQuery query, params string[] columns)
+        => With(name, query, CteMaterialization.Unspecified, columns);
+
+    public SetQueryBuilder With(
+        string name,
+        SqlQuery query,
+        CteMaterialization materialization,
+        params string[] columns)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        var expressions = _statement.CommonTableExpressions?.ToList() ?? [];
+        expressions.Add(new CommonTableExpression(
+            new SqlIdentifier(name),
+            query,
+            columns.Length == 0
+                ? null
+                : columns.Select(static column => new SqlIdentifier(column)).ToArray(),
+            materialization));
+        _statement = _statement with { CommonTableExpressions = expressions };
+        return this;
+    }
+
+    public SetQueryBuilder Recursive(bool value = true)
+    {
+        _statement = _statement with { IsRecursive = value };
+        return this;
+    }
+
+    public ExplainBuilder Explain(bool analyze = false) => new(Build(), analyze);
 
     public SetOperationStatement Build() => _statement;
 
     public string ToSql(SqlDialect? dialect = null, SqlGenerationOptions? options = null) =>
         Build().ToSql(dialect, options);
+
+    private void AddOperation(SetOperator @operator, SqlQuery right, bool all)
+    {
+        ArgumentNullException.ThrowIfNull(right);
+        _statement = new SetOperationStatement(_statement, @operator, right, all);
+    }
 }

--- a/src/Cyqwel/Builders/Sql.cs
+++ b/src/Cyqwel/Builders/Sql.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Cyqwel.Ast;
 
 namespace Cyqwel;
@@ -11,9 +12,52 @@ public static class Sql
 
     public static StarExpression Star() => new();
 
-    public static LiteralExpression Lit(object? value) => new(value);
+    public static StarExpression Star(string qualifier)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(qualifier);
+        if (qualifier.Contains('.'))
+        {
+            throw new ArgumentException(
+                "Qualified stars support one identifier part.",
+                nameof(qualifier));
+        }
+
+        return new([new SqlIdentifier(qualifier)]);
+    }
+
+    public static LiteralExpression Lit(object? value)
+    {
+        if (!IsSupportedLiteralValue(value))
+        {
+            throw new ArgumentException(
+                $"Literal type '{value!.GetType().Name}' is not supported by the SQL parser.",
+                nameof(value));
+        }
+
+        if (IsUnsupportedFloatingPoint(value))
+        {
+            throw new ArgumentException(
+                "Floating-point literals must be finite and use non-exponential notation.",
+                nameof(value));
+        }
+
+        return new LiteralExpression(value);
+    }
 
     public static ParameterExpression Param(string name, char prefix = '@') => new(name, prefix);
+
+    public static SqlDocument Document(params SqlStatement[] statements)
+    {
+        ArgumentNullException.ThrowIfNull(statements);
+        if (statements.Length == 0)
+        {
+            throw new ArgumentException("At least one statement is required.", nameof(statements));
+        }
+
+        return new SqlDocument(statements);
+    }
+
+    public static ParenthesizedExpression Parenthesize(SqlExpression expression) => new(expression);
 
     public static FunctionCallExpression Func(string name, params SqlExpression[] arguments) =>
         new(name, arguments);
@@ -26,6 +70,132 @@ public static class Sql
     public static CastExpression Cast(SqlExpression expression, string dataType, params int[] arguments) =>
         new(expression, new SqlDataType(dataType, arguments));
 
+    public static TryCastExpression TryCast(SqlExpression expression, string dataType, params int[] arguments) =>
+        new(expression, new SqlDataType(dataType, arguments));
+
+    public static ExistsExpression Exists(SqlQuery query, bool negated = false) => new(query, negated);
+
+    public static SubqueryExpression Subquery(SqlQuery query) => new(query);
+
+    public static RowExpression Row(params SqlExpression[] values)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+        if (values.Length == 0)
+        {
+            throw new ArgumentException("At least one row value is required.", nameof(values));
+        }
+
+        return new RowExpression(values);
+    }
+
+    public static DefaultExpression Default() => new();
+
+    public static ExtractExpression Extract(string field, SqlExpression expression) =>
+        new(new SqlIdentifier(field), expression);
+
+    public static IntervalExpression Interval(object value, string unit)
+    {
+        var expression = Coerce(value);
+        if (expression is LiteralExpression literal && IsUnsupportedFloatingPoint(literal.Value))
+        {
+            throw new ArgumentException(
+                "Floating-point interval values must be finite and use non-exponential notation.",
+                nameof(value));
+        }
+
+        if (expression is not ParameterExpression
+            && expression is not LiteralExpression { Value: string or char or DateTime or DateTimeOffset }
+            && expression is not LiteralExpression { Value: byte or sbyte or short or ushort or int or uint
+                or long or ulong or float or double or decimal })
+        {
+            throw new ArgumentException(
+                "Interval values must be numeric, textual, temporal, or parameter expressions.",
+                nameof(value));
+        }
+
+        return new IntervalExpression(expression, new SqlIdentifier(unit));
+    }
+
+    public static SequenceValueExpression NextValue(string sequence) =>
+        new(new TableName(sequence), SequenceValueKind.Next);
+
+    public static SequenceValueExpression CurrentValue(string sequence) =>
+        new(new TableName(sequence), SequenceValueKind.Current);
+
+    public static OrderByItem Order(
+        SqlExpression expression,
+        OrderDirection direction = OrderDirection.Ascending,
+        NullOrder nullOrder = NullOrder.Unspecified) =>
+        new(expression, direction, nullOrder);
+
+    public static WindowFrameBound UnboundedPreceding() =>
+        new(WindowFrameBoundKind.UnboundedPreceding);
+
+    public static WindowFrameBound Preceding(object offset) =>
+        new(WindowFrameBoundKind.Preceding, Coerce(offset));
+
+    public static WindowFrameBound CurrentRow() =>
+        new(WindowFrameBoundKind.CurrentRow);
+
+    public static WindowFrameBound Following(object offset) =>
+        new(WindowFrameBoundKind.Following, Coerce(offset));
+
+    public static WindowFrameBound UnboundedFollowing() =>
+        new(WindowFrameBoundKind.UnboundedFollowing);
+
+    public static WindowFrame Frame(
+        WindowFrameUnit unit,
+        WindowFrameBound start,
+        WindowFrameBound? end = null)
+    {
+        ArgumentNullException.ThrowIfNull(start);
+        ValidateWindowFrameBound(start, nameof(start));
+        if (end is null)
+        {
+            if (start.Kind is WindowFrameBoundKind.Following
+                or WindowFrameBoundKind.UnboundedFollowing)
+            {
+                throw new ArgumentException(
+                    "A single window frame bound cannot use FOLLOWING.",
+                    nameof(start));
+            }
+
+            return new WindowFrame(unit, start);
+        }
+
+        ValidateWindowFrameBound(end, nameof(end));
+        if (start.Kind == WindowFrameBoundKind.UnboundedFollowing)
+        {
+            throw new ArgumentException(
+                "A window frame cannot start with UNBOUNDED FOLLOWING.",
+                nameof(start));
+        }
+
+        if (end.Kind == WindowFrameBoundKind.UnboundedPreceding)
+        {
+            throw new ArgumentException(
+                "A window frame cannot end with UNBOUNDED PRECEDING.",
+                nameof(end));
+        }
+
+        if (GetWindowFrameBoundRank(start.Kind) > GetWindowFrameBoundRank(end.Kind))
+        {
+            throw new ArgumentException(
+                "The window frame start must not follow its end.",
+                nameof(start));
+        }
+
+        return new WindowFrame(unit, start, end);
+    }
+
+    public static NamedTable Table(string name, string? alias = null) => new(name, alias);
+
+    public static DerivedTable Derived(SqlQuery query, string alias) =>
+        new(query, new SqlIdentifier(alias));
+
+    public static Assignment Assign(string column, object? value) =>
+        new(Col(column), Coerce(value));
+
     public static SelectBuilder Select(params string[] columns) =>
         new(columns.Select(static column => new SelectItem(Col(column))).ToArray());
 
@@ -34,14 +204,189 @@ public static class Sql
 
     public static SelectBuilder SelectItems(params SelectItem[] items) => new(items);
 
+    public static ValuesBuilder Values(params object?[] values) =>
+        new(values.Select(Coerce).ToArray());
+
+    public static ExplainBuilder Explain(SqlQuery query, bool analyze = false) => new(query, analyze);
+
     public static InsertBuilder InsertInto(string table) => new(table);
 
     public static UpdateBuilder Update(string table, string? alias = null) => new(table, alias);
 
     public static DeleteBuilder DeleteFrom(string table, string? alias = null) => new(table, alias);
 
+    public static MergeBuilder MergeInto(string table, string? alias = null) => new(table, alias);
+
+    public static CreateTableBuilder CreateTable(string table) => new(table);
+
+    public static AlterTableBuilder AlterTable(string table) => new(table);
+
+    public static DropBuilder Drop(SchemaObjectKind kind, string name) => new(kind, name);
+
+    public static DropBuilder DropTable(string table) => Drop(SchemaObjectKind.Table, table);
+
+    public static TruncateBuilder Truncate(string table) => new(table);
+
+    public static CreateViewBuilder CreateView(string view) => new(view);
+
+    public static CreateIndexBuilder CreateIndex(string index, string table) => new(index, table);
+
+    public static CreateSequenceBuilder CreateSequence(string sequence) => new(sequence);
+
+    public static AlterSequenceBuilder AlterSequence(string sequence) => new(sequence);
+
+    public static ColumnDefinition DefineColumn(
+        string name,
+        SqlDataType dataType,
+        Nullability nullability = Nullability.Unspecified,
+        SqlExpression? defaultValue = null,
+        SqlExpression? generatedExpression = null,
+        GeneratedColumnKind generatedKind = GeneratedColumnKind.Virtual,
+        IdentityGeneration identity = IdentityGeneration.None,
+        bool primaryKey = false,
+        bool unique = false)
+    {
+        ArgumentNullException.ThrowIfNull(dataType);
+        var generatedClauseCount =
+            (defaultValue is null ? 0 : 1)
+            + (generatedExpression is null ? 0 : 1)
+            + (identity == IdentityGeneration.None ? 0 : 1);
+        if (generatedClauseCount > 1)
+        {
+            throw new ArgumentException(
+                "DEFAULT, generated expressions, and identity generation are mutually exclusive.");
+        }
+
+        return new(
+            new SqlIdentifier(name),
+            dataType,
+            nullability,
+            defaultValue,
+            generatedExpression,
+            generatedKind,
+            identity,
+            primaryKey,
+            unique);
+    }
+
+    public static PrimaryKeyConstraint PrimaryKey(
+        IReadOnlyList<string> columns,
+        string? name = null)
+    {
+        ValidateColumns(columns, nameof(columns));
+        return new(
+            columns.Select(static column => new SqlIdentifier(column)).ToArray(),
+            name is null ? null : new SqlIdentifier(name));
+    }
+
+    public static UniqueConstraint Unique(
+        IReadOnlyList<string> columns,
+        string? name = null)
+    {
+        ValidateColumns(columns, nameof(columns));
+        return new(
+            columns.Select(static column => new SqlIdentifier(column)).ToArray(),
+            name is null ? null : new SqlIdentifier(name));
+    }
+
+    public static ForeignKeyConstraint ForeignKey(
+        IReadOnlyList<string> columns,
+        string referencedTable,
+        IReadOnlyList<string> referencedColumns,
+        ReferentialAction onDelete = ReferentialAction.Unspecified,
+        ReferentialAction onUpdate = ReferentialAction.Unspecified,
+        string? name = null)
+    {
+        ValidateColumns(columns, nameof(columns));
+        ValidateColumns(referencedColumns, nameof(referencedColumns));
+        if (columns.Count != referencedColumns.Count)
+        {
+            throw new ArgumentException(
+                "Foreign key and referenced column counts must match.",
+                nameof(referencedColumns));
+        }
+
+        return new(
+            columns.Select(static column => new SqlIdentifier(column)).ToArray(),
+            new TableName(referencedTable),
+            referencedColumns.Select(static column => new SqlIdentifier(column)).ToArray(),
+            onDelete,
+            onUpdate,
+            name is null ? null : new SqlIdentifier(name));
+    }
+
+    public static CheckConstraint Check(SqlExpression condition, string? name = null) =>
+        new(condition, name is null ? null : new SqlIdentifier(name));
+
     public static CaseBuilder Case(SqlExpression? operand = null) => new(operand);
 
     internal static SqlExpression Coerce(object? value) =>
         value as SqlExpression ?? Lit(value);
+
+    private static void ValidateColumns(IReadOnlyList<string> columns, string parameterName)
+    {
+        ArgumentNullException.ThrowIfNull(columns, parameterName);
+        if (columns.Count == 0)
+        {
+            throw new ArgumentException("At least one column is required.", parameterName);
+        }
+    }
+
+    private static void ValidateWindowFrameBound(WindowFrameBound bound, string parameterName)
+    {
+        var requiresOffset = bound.Kind is WindowFrameBoundKind.Preceding
+            or WindowFrameBoundKind.Following;
+        if (requiresOffset != (bound.Offset is not null))
+        {
+            throw new ArgumentException(
+                requiresOffset
+                    ? "PRECEDING and FOLLOWING bounds require an offset."
+                    : "Only PRECEDING and FOLLOWING bounds can have an offset.",
+                parameterName);
+        }
+    }
+
+    private static int GetWindowFrameBoundRank(WindowFrameBoundKind kind) =>
+        kind switch
+        {
+            WindowFrameBoundKind.UnboundedPreceding => 0,
+            WindowFrameBoundKind.Preceding => 1,
+            WindowFrameBoundKind.CurrentRow => 2,
+            WindowFrameBoundKind.Following => 3,
+            WindowFrameBoundKind.UnboundedFollowing => 4,
+            _ => throw new ArgumentOutOfRangeException(nameof(kind)),
+        };
+
+    private static bool IsUnsupportedFloatingPoint(object? value)
+    {
+        var text = value switch
+        {
+            float number when float.IsFinite(number) =>
+                number.ToString(null, CultureInfo.InvariantCulture),
+            double number when double.IsFinite(number) =>
+                number.ToString(null, CultureInfo.InvariantCulture),
+            float or double => null,
+            _ => string.Empty,
+        };
+        return text is null || text.Contains('E') || text.Contains('e');
+    }
+
+    private static bool IsSupportedLiteralValue(object? value) =>
+        value is null
+            or bool
+            or string
+            or char
+            or DateTime
+            or DateTimeOffset
+            or byte
+            or sbyte
+            or short
+            or ushort
+            or int
+            or uint
+            or long
+            or ulong
+            or float
+            or double
+            or decimal;
 }

--- a/src/Cyqwel/Dialects/SqlDialect.cs
+++ b/src/Cyqwel/Dialects/SqlDialect.cs
@@ -72,6 +72,8 @@ public class SqlDialect
 
     public virtual bool SupportsExplain => ParserOptions.SupportsExplainOptions;
 
+    public virtual bool SupportsParenthesizedSetOperands => true;
+
     public virtual bool UsesSqlSecurityForViews => false;
 
     public virtual SqlConcatenationStyle ConcatenationStyle => SqlConcatenationStyle.DoublePipe;
@@ -211,6 +213,8 @@ public static class SqlDialects
 
     private sealed class SqliteDialect() : SqlDialect("sqlite")
     {
+        public override bool SupportsParenthesizedSetOperands => false;
+
         public override SqlDialectParserOptions ParserOptions { get; } = new()
         {
             IdentifierQuotes = SqlIdentifierQuoteStyle.DoubleQuote
@@ -583,6 +587,7 @@ public sealed class SqlDialectBuilder
         public override bool SupportsILike => baseDialect.SupportsILike;
         public override bool SupportsReturning => baseDialect.SupportsReturning;
         public override bool SupportsReturningInto => baseDialect.SupportsReturningInto;
+        public override bool SupportsParenthesizedSetOperands => baseDialect.SupportsParenthesizedSetOperands;
         public override bool RequiresOrderByForOffset => baseDialect.RequiresOrderByForOffset;
         public override bool SupportsTableAliasAs => baseDialect.SupportsTableAliasAs;
         public override bool UsesSqlSecurityForViews => baseDialect.UsesSqlSecurityForViews;

--- a/src/Cyqwel/Generation/SqlGenerator.cs
+++ b/src/Cyqwel/Generation/SqlGenerator.cs
@@ -207,7 +207,11 @@ public sealed partial class SqlGenerator
     private void WriteSetOperation(SetOperationStatement set)
     {
         WriteCommonTableExpressions(set.CommonTableExpressions, set.IsRecursive);
-        WriteQueryOperand(set.Left, set.Operator);
+        WriteQueryOperand(
+            set.Left,
+            set.Operator,
+            forceParentheses: set.CommonTableExpressions is { Count: > 0 }
+                && HasCommonTableExpressions(set.Left));
         ClauseBreak();
         Keyword(_dialect.GetSetOperator(set.Operator));
 
@@ -226,13 +230,23 @@ public sealed partial class SqlGenerator
     private void WriteQueryOperand(
         SqlQuery query,
         SetOperator? parentOperator = null,
-        bool isRightOperand = false)
+        bool isRightOperand = false,
+        bool forceParentheses = false)
     {
-        var parenthesize = query is SetOperationStatement child
-            && (parentOperator is null
-                || GetSetOperatorPrecedence(child.Operator) < GetSetOperatorPrecedence(parentOperator.Value)
-                || isRightOperand
-                    && GetSetOperatorPrecedence(child.Operator) == GetSetOperatorPrecedence(parentOperator.Value));
+        var parenthesize = forceParentheses
+            || HasOperandLocalModifiers(query)
+            || isRightOperand && HasCommonTableExpressions(query)
+            || query is SetOperationStatement child
+                && (parentOperator is null
+                    || GetSetOperatorPrecedence(child.Operator) < GetSetOperatorPrecedence(parentOperator.Value)
+                    || isRightOperand
+                        && GetSetOperatorPrecedence(child.Operator) == GetSetOperatorPrecedence(parentOperator.Value));
+        if (parenthesize && !_dialect.SupportsParenthesizedSetOperands)
+        {
+            Unsupported($"{_dialect.Name} cannot represent a parenthesized set operand.");
+            parenthesize = false;
+        }
+
         if (parenthesize)
         {
             _builder.Append('(');
@@ -244,6 +258,33 @@ public sealed partial class SqlGenerator
             WriteNode(query);
         }
     }
+
+    private static bool HasOperandLocalModifiers(SqlQuery query) =>
+        query switch
+        {
+            SelectStatement select =>
+                select.OrderBy is { Count: > 0 }
+                || select.Limit is not null
+                || select.Offset is not null,
+            ValuesStatement values =>
+                values.OrderBy is { Count: > 0 }
+                || values.Limit is not null
+                || values.Offset is not null,
+            SetOperationStatement set =>
+                set.OrderBy is { Count: > 0 }
+                || set.Limit is not null
+                || set.Offset is not null,
+            _ => false,
+        };
+
+    private static bool HasCommonTableExpressions(SqlQuery query) =>
+        query switch
+        {
+            SelectStatement select => select.CommonTableExpressions is { Count: > 0 },
+            ValuesStatement values => values.CommonTableExpressions is { Count: > 0 },
+            SetOperationStatement set => set.CommonTableExpressions is { Count: > 0 },
+            _ => false,
+        };
 
     private static int GetSetOperatorPrecedence(SetOperator value) =>
         value == SetOperator.Intersect ? 2 : 1;
@@ -666,7 +707,7 @@ public sealed partial class SqlGenerator
                 WriteBinary(binary, precedence);
                 break;
             case BetweenExpression between:
-                WriteExpression(between.Expression, precedence);
+                WriteExpression(between.Expression, precedence + 1);
                 Space();
                 if (between.IsNegated) Keyword("NOT ");
                 Keyword("BETWEEN");
@@ -678,7 +719,7 @@ public sealed partial class SqlGenerator
                 WriteExpression(between.Upper, precedence + 1);
                 break;
             case InExpression @in:
-                WriteExpression(@in.Expression, precedence);
+                WriteExpression(@in.Expression, precedence + 1);
                 Space();
                 if (@in.IsNegated) Keyword("NOT ");
                 Keyword("IN");
@@ -688,12 +729,12 @@ public sealed partial class SqlGenerator
                 _builder.Append(')');
                 break;
             case IsNullExpression isNull:
-                WriteExpression(isNull.Expression, precedence);
+                WriteExpression(isNull.Expression, precedence + 1);
                 Space();
                 Keyword(isNull.IsNegated ? "IS NOT NULL" : "IS NULL");
                 break;
             case BooleanTestExpression booleanTest:
-                WriteExpression(booleanTest.Expression, precedence);
+                WriteExpression(booleanTest.Expression, precedence + 1);
                 Space();
                 Keyword(booleanTest.IsNegated ? "IS NOT" : "IS");
                 Space();
@@ -706,14 +747,15 @@ public sealed partial class SqlGenerator
                 });
                 break;
             case DistinctFromExpression distinct:
-                WriteExpression(distinct.Left, precedence);
+                WriteExpression(distinct.Left, precedence + 1);
                 Space();
                 Keyword(distinct.IsNegated ? "IS NOT DISTINCT FROM" : "IS DISTINCT FROM");
                 Space();
                 WriteExpression(distinct.Right, precedence + 1);
                 break;
             case RowExpression row:
-                _builder.Append('(');
+                Keyword("ROW");
+                _builder.Append(" (");
                 WriteSeparated(row.Values, value => WriteExpression(value));
                 _builder.Append(')');
                 break;
@@ -721,7 +763,7 @@ public sealed partial class SqlGenerator
                 Keyword("DEFAULT");
                 break;
             case CollateExpression collate:
-                WriteExpression(collate.Expression, precedence);
+                WriteExpression(collate.Expression, precedence + 1);
                 Space();
                 Keyword("COLLATE");
                 Space();
@@ -809,7 +851,7 @@ public sealed partial class SqlGenerator
             UnaryOperator.ConnectByRoot => KeywordText("CONNECT_BY_ROOT") + " ",
             _ => throw new ArgumentOutOfRangeException(),
         });
-        WriteExpression(unary.Operand, GetPrecedence(unary));
+        WriteExpression(unary.Operand, GetPrecedence(unary) + 1);
     }
 
     private void WriteBinary(BinaryExpression binary, int precedence)
@@ -927,6 +969,16 @@ public sealed partial class SqlGenerator
         WriteExpression(window.Expression);
         Space();
         Keyword("OVER");
+        if (window.WindowName is not null
+            && window.PartitionBy is not { Count: > 0 }
+            && window.OrderBy is not { Count: > 0 }
+            && window.Frame is null)
+        {
+            Space();
+            WriteIdentifier(window.WindowName);
+            return;
+        }
+
         _builder.Append(" (");
         var hasClause = false;
         if (window.WindowName is not null)
@@ -1154,7 +1206,7 @@ public sealed partial class SqlGenerator
         BinaryExpression { Operator: BinaryOperator.BitwiseAnd } => 5,
         BinaryExpression { Operator: BinaryOperator.Add or BinaryOperator.Subtract or BinaryOperator.Concatenate } => 6,
         BinaryExpression { Operator: BinaryOperator.Multiply or BinaryOperator.Divide or BinaryOperator.Modulo } => 7,
-        UnaryExpression => 8,
+        UnaryExpression or CollateExpression => 8,
         ParenthesizedExpression or WindowExpression or RowExpression => 9,
         _ => 9,
     };

--- a/src/Cyqwel/Parsing/SqlParser.cs
+++ b/src/Cyqwel/Parsing/SqlParser.cs
@@ -156,6 +156,8 @@ public static class SqlParser
         var VIRTUAL = Keyword("VIRTUAL");
         var STORED = Keyword("STORED");
         var ADD = Keyword("ADD");
+        var RESTART = Keyword("RESTART");
+        var SCHEMA = Keyword("SCHEMA");
         var CYCLE = Keyword("CYCLE");
         var CACHE = Keyword("CACHE");
         var MINVALUE = Keyword("MINVALUE");
@@ -275,10 +277,17 @@ public static class SqlParser
             leftParenthesis,
             WHERE.SkipAnd(expression),
             rightParenthesis));
+        var namedWindowReference = simpleIdentifier.Then(value => new ParsedWindow(
+            null,
+            null,
+            null,
+            value));
+        var over = OVER.SkipAnd(
+            namedWindowReference.Or(Between(leftParenthesis, windowSpecification, rightParenthesis)));
         var function = functionCore
             .And(withinGroup.Optional())
             .And(functionFilter.Optional())
-            .And(OVER.SkipAnd(Between(leftParenthesis, windowSpecification, rightParenthesis)).Optional())
+            .And(over.Optional())
             .Then<SqlExpression>(value =>
             {
                 var call = value.Item1 with
@@ -381,13 +390,14 @@ public static class SqlParser
             .AndSkip(THEN)
             .And(expression)
             .Then(value => new WhenClause(value.Item1, value.Item2));
-        var caseExpression = CASE.SkipAnd(OneOrMany(whenClause))
+        var caseExpression = CASE.SkipAnd(expression.Optional())
+            .And(OneOrMany(whenClause))
             .And(ELSE.SkipAnd(expression).Optional())
             .AndSkip(END)
             .Then<SqlExpression>(value => new CaseExpression(
-                null,
-                value.Item1,
-                value.Item2.HasValue ? value.Item2.Value : null));
+                value.Item1.HasValue ? value.Item1.Value : null,
+                value.Item2,
+                value.Item3.HasValue ? value.Item3.Value : null));
 
         var exists = NOT.Optional()
             .AndSkip(EXISTS)
@@ -497,7 +507,7 @@ public static class SqlParser
         var inQuery = query.Then(value => new InTarget(Array.Empty<SqlExpression>(), value));
         var inSuffix = NOT.Optional()
             .AndSkip(IN)
-            .And(Between(leftParenthesis, inQuery.Or(inValues), rightParenthesis))
+            .And(Between(leftParenthesis, inValues.Or(inQuery), rightParenthesis))
             .Then<Func<SqlExpression, SqlExpression>>(value => target => new InExpression(
                 target,
                 value.Item2.Values,
@@ -604,7 +614,18 @@ public static class SqlParser
                 .Then(value => (Start: value.Item1, End: (WindowFrameBound?)value.Item2))
                 .Or(windowFrameBound.Then(value => (Start: value, End: (WindowFrameBound?)null))))
             .Then(value => new WindowFrame(value.Item1, value.Item2.Start, value.Item2.End));
-        windowSpecification.Parser = windowPartitionBy.Optional()
+        var baseWindowIdentifier = simpleIdentifier.When(
+            (_, identifier) => !identifier.Value.Equals("PARTITION", StringComparison.OrdinalIgnoreCase));
+        var namedWindowSpecification = baseWindowIdentifier
+            .And(windowPartitionBy.Optional())
+            .And(windowOrderBy.Optional())
+            .And(windowFrame.Optional())
+            .Then(value => new ParsedWindow(
+                value.Item2.HasValue ? value.Item2.Value : null,
+                value.Item3.HasValue ? value.Item3.Value : null,
+                value.Item4.HasValue ? value.Item4.Value : null,
+                value.Item1));
+        var anonymousWindowSpecification = windowPartitionBy.Optional()
             .And(windowOrderBy.Optional())
             .And(windowFrame.Optional())
             .Then(value => new ParsedWindow(
@@ -612,6 +633,7 @@ public static class SqlParser
                 value.Item2.HasValue ? value.Item2.Value : null,
                 value.Item3.HasValue ? value.Item3.Value : null,
                 null));
+        windowSpecification.Parser = namedWindowSpecification.Or(anonymousWindowSpecification);
 
         var alias = AS.SkipAnd(simpleIdentifier).Or(nonKeywordIdentifier);
         var tableAlias = syntax.SupportsTableAliasAs
@@ -804,7 +826,10 @@ public static class SqlParser
         var valueRow = Between(leftParenthesis, Separated(comma, expression), rightParenthesis);
         var valuesCore = VALUES.SkipAnd(Separated(comma, valueRow))
             .Then<SqlQuery>(rows => new ValuesStatement(rows));
-        var queryPrimary = selectCore.Then<SqlQuery>(value => value).Or(valuesCore);
+        var parenthesizedQuery = Between(leftParenthesis, query, rightParenthesis);
+        var queryPrimary = parenthesizedQuery
+            .Or(selectCore.Then<SqlQuery>(value => value))
+            .Or(valuesCore);
         var setTail = setOperator.And(ALL.Optional()).And(queryPrimary)
             .Then(value => new SetTail(value.Item1, value.Item3, value.Item2.HasValue));
 
@@ -1054,17 +1079,26 @@ public static class SqlParser
             .Then<TableConstraint>(value => new UniqueConstraint(
                 value.Item2,
                 value.Item1.HasValue ? value.Item1.Value : null));
+        var referentialAction = CASCADE.Then(ReferentialAction.Cascade)
+            .Or(RESTRICT.Then(ReferentialAction.Restrict))
+            .Or(SET.SkipAnd(NULL).Then(ReferentialAction.SetNull))
+            .Or(SET.SkipAnd(DEFAULT).Then(ReferentialAction.SetDefault))
+            .Or(NO.SkipAnd(ACTION).Then(ReferentialAction.NoAction));
+        var onDeleteAction = ON.SkipAnd(DELETE).SkipAnd(referentialAction);
+        var onUpdateAction = ON.SkipAnd(UPDATE).SkipAnd(referentialAction);
         var foreignKeyConstraint = constraintName
             .And(FOREIGN.SkipAnd(KEY).SkipAnd(identifierList))
             .AndSkip(REFERENCES)
             .And(tableName)
             .And(identifierList)
+            .And(onDeleteAction.Optional())
+            .And(onUpdateAction.Optional())
             .Then<TableConstraint>(value => new ForeignKeyConstraint(
                 value.Item2,
                 value.Item3,
                 value.Item4,
-                ReferentialAction.Unspecified,
-                ReferentialAction.Unspecified,
+                value.Item5.HasValue ? value.Item5.Value : ReferentialAction.Unspecified,
+                value.Item6.HasValue ? value.Item6.Value : ReferentialAction.Unspecified,
                 value.Item1.HasValue ? value.Item1.Value : null));
         var checkConstraint = constraintName
             .And(CHECK.SkipAnd(Between(leftParenthesis, expression, rightParenthesis)))
@@ -1173,6 +1207,7 @@ public static class SqlParser
         var schemaObjectKind = TABLE.Then(SchemaObjectKind.Table)
             .Or(VIEW.Then(SchemaObjectKind.View))
             .Or(INDEX.Then(SchemaObjectKind.Index))
+            .Or(SCHEMA.Then(SchemaObjectKind.Schema))
             .Or(SEQUENCE.Then(SchemaObjectKind.Sequence));
         var dropStatement = DROP.SkipAnd(schemaObjectKind)
             .And(IF.SkipAnd(EXISTS).Optional())
@@ -1185,10 +1220,12 @@ public static class SqlParser
                 value.Item4.HasValue));
         var truncateStatement = TRUNCATE.SkipAnd(TABLE.Optional())
             .SkipAnd(Separated(comma, tableName))
+            .And(RESTART.SkipAnd(IDENTITY).Optional())
             .And(CASCADE.Optional())
             .Then<SqlStatement>(value => new TruncateStatement(
                 value.Item1,
-                Cascade: value.Item2.HasValue));
+                RestartIdentity: value.Item2.HasValue,
+                Cascade: value.Item3.HasValue));
 
         var addColumn = ADD.SkipAnd(COLUMN.Optional()).SkipAnd(columnDefinition)
             .Then<AlterTableAction>(value => new AddColumnAction(value));

--- a/tests/Cyqwel.Tests/BuilderParityTests.cs
+++ b/tests/Cyqwel.Tests/BuilderParityTests.cs
@@ -1,0 +1,534 @@
+using Cyqwel.Ast;
+using Cyqwel.Dialects;
+
+namespace Cyqwel.Tests;
+
+public class BuilderParityTests
+{
+    [Fact]
+    public void Builder_generated_concepts_are_parseable_by_a_supported_dialect()
+    {
+        var advancedQuery = Sql.SelectItems(
+                new SelectItem(Sql.Star("sales")),
+                new SelectItem(
+                    Sql.Case(Sql.Col("status"))
+                        .When(Sql.Lit("active"), 1)
+                        .Else(0)
+                        .Build(),
+                    "status_code"),
+                new SelectItem(
+                    Sql.Func("PERCENTILE_CONT", Sql.Lit(0.5m))
+                        .WithinGroupBy(Sql.Order(Sql.Col("amount")))
+                        .FilterWhere(Sql.Col("amount").GreaterThan(Sql.Lit(0)))
+                        .Over(
+                            "regional",
+                            partitionBy: null,
+                            orderBy: [Sql.Order(Sql.Col("created_at"))]),
+                    "regional_percentile"),
+                new SelectItem(Sql.Interval(1, "DAY"), "one_day"),
+                new SelectItem(Sql.Row(Sql.Lit(1), Sql.Lit(2)), "pair"),
+                new SelectItem(Sql.NextValue("report_sequence"), "report_id"))
+            .From("sales")
+            .With(
+                "seed",
+                Sql.Select(Sql.Lit(1)).Build(),
+                CteMaterialization.Materialized,
+                "id")
+            .Recursive()
+            .Window("base_window", partitionBy: [Sql.Col("region")])
+            .Window(
+                "regional",
+                baseWindow: "base_window",
+                orderBy: [Sql.Order(Sql.Col("amount"), OrderDirection.Descending)])
+            .Qualify(Sql.Col("regional_percentile").GreaterThan(Sql.Lit(10)))
+            .ConnectBy(
+                Sql.Col("id").Prior().EqualTo(Sql.Col("parent_id")),
+                Sql.Col("parent_id").IsNull(),
+                noCycle: true)
+            .OrderSiblingsBy(Sql.Col("id"))
+            .Build();
+
+        var groupedSet = Sql.Values(1)
+            .Limit(1)
+            .Union(Sql.Values(2).Build())
+            .With("set_seed", Sql.Values(0).Build())
+            .Build();
+        var source = Sql.Select("id", "name").From("incoming").Build();
+        var createTable = Sql.CreateTable("children")
+            .Column("id", "INT")
+            .Column("parent_id", "INT")
+            .Constraint(Sql.ForeignKey(
+                ["parent_id"],
+                "parents",
+                ["id"],
+                ReferentialAction.SetNull,
+                ReferentialAction.Cascade,
+                "fk_children_parent"))
+            .Build();
+
+        var genericSamples = new (string Name, SqlNode Node)[]
+        {
+            ("qualified star", Sql.Select(Sql.Star("sales")).Build()),
+            ("simple case", Sql.Select(
+                Sql.Case(Sql.Col("status")).When(Sql.Lit("active"), 1).Else(0).Build()).Build()),
+            ("within group", Sql.Select(
+                Sql.Func("PERCENTILE_CONT", Sql.Lit(0.5m))
+                    .WithinGroupBy(Sql.Order(Sql.Col("amount")))).Build()),
+            ("function filter", Sql.Select(
+                Sql.Func("SUM", Sql.Col("amount"))
+                    .FilterWhere(Sql.Col("amount").GreaterThan(Sql.Lit(0)))).Build()),
+            ("named window", Sql.Select(Sql.Func("SUM", Sql.Col("amount")).Over("regional"))
+                .Window("regional", partitionBy: [Sql.Col("region")])
+                .Build()),
+            ("augmented window", Sql.Select(
+                    Sql.Func("SUM", Sql.Col("amount")).Over(
+                        "regional",
+                        partitionBy: null,
+                        orderBy: [Sql.Order(Sql.Col("created_at"))]))
+                .Window("regional", partitionBy: [Sql.Col("region")])
+                .Build()),
+            ("advanced function", Sql.Select(
+                Sql.Func("PERCENTILE_CONT", Sql.Lit(0.5m))
+                    .WithinGroupBy(Sql.Order(Sql.Col("amount")))
+                    .FilterWhere(Sql.Col("amount").GreaterThan(Sql.Lit(0)))
+                    .Over(
+                        "regional",
+                        partitionBy: null,
+                        orderBy: [Sql.Order(Sql.Col("created_at"))]))
+                .Window("regional", partitionBy: [Sql.Col("region")])
+                .Build()),
+            ("interval", Sql.Select(Sql.Interval(1, "DAY")).Build()),
+            ("row", Sql.Select(Sql.Row(Sql.Lit(1), Sql.Lit(2))).Build()),
+            ("sequence value", Sql.Select(Sql.NextValue("report_sequence")).Build()),
+            ("nested unary", Sql.Select(Sql.Col("amount").Negate().Negate()).Build()),
+            ("nested predicate", Sql.Select(Sql.Col("amount").IsNull().IsNull()).Build()),
+            ("base window", Sql.Select(Sql.Func("ROW_NUMBER").Over("regional"))
+                .Window("base_window", partitionBy: [Sql.Col("region")])
+                .Window("regional", baseWindow: "base_window", orderBy: [Sql.Order(Sql.Col("amount"))])
+                .Build()),
+            ("hierarchy", Sql.Select("id")
+                .From("nodes")
+                .ConnectBy(
+                    Sql.Col("id").Prior().EqualTo(Sql.Col("parent_id")),
+                    Sql.Col("parent_id").IsNull(),
+                    noCycle: true)
+                .OrderSiblingsBy(Sql.Col("id"))
+                .Build()),
+            ("materialized cte", Sql.Select(Sql.Lit(1))
+                .With(
+                    "seed",
+                    Sql.Select(Sql.Lit(1)).Build(),
+                    CteMaterialization.Materialized,
+                    "id")
+                .Recursive()
+                .Build()),
+            ("advanced query", advancedQuery),
+            ("grouped set", groupedSet),
+            ("explain", Sql.Explain(groupedSet).Analyze().Parenthesized().Build()),
+            ("document", Sql.Document(
+                Sql.Select(Sql.Lit(1)).Build(),
+                Sql.Select(Sql.Lit(2)).Build())),
+            ("insert", Sql.InsertInto("users")
+                .Columns("id", "name")
+                .From(source)
+                .Returning(Sql.Col("id"))
+                .ReturningInto(Sql.Param("inserted_id"))
+                .Build()),
+            ("update", Sql.Update("users", "u")
+                .Set("name", Sql.Col("i.name"))
+                .From(source, "i")
+                .Where(Sql.Col("u.id").EqualTo(Sql.Col("i.id")))
+                .Returning(Sql.Col("u.id"))
+                .ReturningInto(Sql.Param("updated_id"))
+                .Build()),
+            ("delete", Sql.DeleteFrom("users", "u")
+                .Using("expired", "e")
+                .Where(Sql.Col("u.id").EqualTo(Sql.Col("e.id")))
+                .Returning(Sql.Col("u.id"))
+                .ReturningInto(Sql.Param("deleted_id"))
+                .Build()),
+            ("merge", Sql.MergeInto("users", "u")
+                .Using("incoming", "i")
+                .On(Sql.Col("u.id").EqualTo(Sql.Col("i.id")))
+                .WhenMatchedUpdate(Sql.Assign("name", Sql.Col("i.name")))
+                .WhenNotMatchedInsert(["id", "name"], Sql.Col("i.id"), Sql.Col("i.name"))
+                .WhenNotMatchedBySourceDelete()
+                .Build()),
+            ("create table", createTable),
+            ("alter table", Sql.AlterTable("children")
+                .AddColumn("name", "VARCHAR", 100)
+                .AlterColumn("name", nullability: Nullability.NotNull)
+                .RenameColumn("name", "display_name")
+                .Build()),
+            ("drop schema", Sql.Drop(SchemaObjectKind.Schema, "archive").IfExists().Cascade().Build()),
+            ("truncate", Sql.Truncate("children").RestartIdentity().Cascade().Build()),
+            ("create view", Sql.CreateView("child_view").As(source).Build()),
+            ("create index", Sql.CreateIndex("ix_children_parent", "children")
+                .Column("parent_id")
+                .Where(Sql.Col("parent_id").IsNotNull())
+                .Build()),
+            ("create sequence", Sql.CreateSequence("child_ids")
+                .StartWith(1)
+                .IncrementBy(1)
+                .Cycle(false)
+                .Build()),
+            ("alter sequence", Sql.AlterSequence("child_ids").IncrementBy(2).Cycle().Build()),
+        };
+
+        foreach (var (name, node) in genericSamples)
+        {
+            AssertParseable(name, node, SqlDialects.Generic);
+        }
+
+        AssertParseable(
+            "top percent with ties",
+            Sql.Select("id")
+                .From("users")
+                .OrderBy(Sql.Col("id"))
+                .Top(10, percent: true, withTies: true)
+                .Build(),
+            SqlDialects.TSql);
+        AssertParseable(
+            "view security",
+            Sql.CreateView("secure_view")
+                .Security(ViewSecurity.Definer)
+                .As(source)
+                .Build(),
+            SqlDialects.MySql);
+
+        var parsedQuery = Assert.IsType<SelectStatement>(
+            Assert.Single(SqlDialects.Generic.Parse(advancedQuery.ToSql()).Statements));
+        Assert.NotNull(Assert.IsType<CaseExpression>(parsedQuery.Projections[1].Expression).Operand);
+        Assert.Single(Assert.IsType<StarExpression>(parsedQuery.Projections[0].Expression).Qualifier!);
+        Assert.Equal(
+            "regional",
+            Assert.IsType<WindowExpression>(parsedQuery.Projections[2].Expression).WindowName!.Value);
+        Assert.Equal("base_window", parsedQuery.Windows![1].BaseWindow!.Value);
+
+        var parsedCreate = Assert.IsType<CreateTableStatement>(
+            Assert.Single(SqlDialects.Generic.Parse(createTable.ToSql()).Statements));
+        var foreignKey = Assert.Single(parsedCreate.Elements.OfType<ForeignKeyConstraint>());
+        Assert.Equal(ReferentialAction.SetNull, foreignKey.OnDelete);
+        Assert.Equal(ReferentialAction.Cascade, foreignKey.OnUpdate);
+
+        var parsedTruncate = Assert.IsType<TruncateStatement>(
+            Assert.Single(SqlDialects.Generic.Parse(
+                Sql.Truncate("children").RestartIdentity().Build().ToSql()).Statements));
+        Assert.True(parsedTruncate.RestartIdentity);
+    }
+
+    [Fact]
+    public void Select_builder_covers_advanced_query_clauses()
+    {
+        var cte = Sql.Select("id").From("source").Build();
+        var frame = Sql.Frame(
+            WindowFrameUnit.Rows,
+            Sql.UnboundedPreceding(),
+            Sql.CurrentRow());
+        var rowNumber = Sql.Func("ROW_NUMBER").Over("regional");
+
+        var query = Sql.SelectItems(new SelectItem(rowNumber, "position"))
+            .From("sales")
+            .With("regional_sales", cte, CteMaterialization.NotMaterialized, "id")
+            .Recursive()
+            .Window(
+                "regional",
+                partitionBy: [Sql.Col("region")],
+                orderBy: [Sql.Order(Sql.Col("amount"), OrderDirection.Descending)],
+                frame: frame)
+            .Qualify(Sql.Col("position").LessThanOrEqualTo(Sql.Lit(3)))
+            .Build();
+
+        Assert.True(query.IsRecursive);
+        Assert.Equal(CteMaterialization.NotMaterialized, query.CommonTableExpressions![0].Materialization);
+        Assert.Single(query.Windows!);
+        Assert.NotNull(query.Qualify);
+        Assert.Equal("regional", Assert.IsType<WindowExpression>(query.Projections[0].Expression).WindowName!.Value);
+
+        var sql = query.ToSql();
+        Assert.Contains("WITH RECURSIVE regional_sales(id) AS NOT MATERIALIZED", sql);
+        Assert.Contains("WINDOW regional AS (PARTITION BY region ORDER BY amount DESC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)", sql);
+        Assert.Contains("QUALIFY position <= 3", sql);
+    }
+
+    [Fact]
+    public void Select_builder_covers_advanced_joins_hierarchies_and_top()
+    {
+        var query = Sql.Select("e.id")
+            .From(Sql.Table("employees", "e"))
+            .JoinUsing("departments", ["department_id"], "d", JoinKind.Left)
+            .NaturalJoin("locations")
+            .CommaJoin(Sql.Derived(Sql.Select("id").From("roles").Build(), "r"))
+            .ConnectBy(
+                new UnaryExpression(UnaryOperator.Prior, Sql.Col("e.id"))
+                    .EqualTo(Sql.Col("e.manager_id")),
+                Sql.Col("e.manager_id").IsNull(),
+                noCycle: true)
+            .OrderSiblingsBy(Sql.Col("e.id"))
+            .Top(10, percent: true, withTies: true)
+            .Build();
+
+        Assert.True(query.IsTopPercent);
+        Assert.True(query.WithTies);
+        Assert.True(query.OrderSiblings);
+        Assert.NotNull(query.ConnectBy);
+
+        var genericSql = (query with
+        {
+            Top = null,
+            IsTopPercent = false,
+            WithTies = false,
+        }).ToSql();
+        Assert.Contains("LEFT JOIN departments AS d USING (department_id)", genericSql);
+        Assert.Contains("NATURAL INNER JOIN locations", genericSql);
+        Assert.Contains(", (SELECT id FROM roles) AS r", genericSql);
+        Assert.Contains("CONNECT BY NOCYCLE PRIOR e.id = e.manager_id", genericSql);
+        Assert.Contains("ORDER SIBLINGS BY e.id ASC", genericSql);
+
+        var topSql = Sql.Select("id")
+            .From("users")
+            .OrderBy(Sql.Col("id"))
+            .Top(10, percent: true, withTies: true)
+            .ToSql(SqlDialects.TSql);
+        Assert.Contains("TOP (10) PERCENT WITH TIES", topSql);
+    }
+
+    [Fact]
+    public void Values_set_and_explain_builders_are_composable()
+    {
+        var set = Sql.Values(1, "one")
+            .Row(2, "two")
+            .Union(Sql.Select(Sql.Lit(3), Sql.Lit("three")).Build(), all: true)
+            .Intersect(Sql.Values(3, "three").Build())
+            .Except(Sql.Select(Sql.Lit(4), Sql.Lit("four")).Build())
+            .OrderBy(Sql.Col("1"))
+            .ThenBy(Sql.Col("2"), OrderDirection.Descending)
+            .Limit(Sql.Param("limit"))
+            .Offset(Sql.Lit(1))
+            .With("seed", Sql.Values(0, "zero").Build())
+            .Recursive()
+            .Build();
+
+        Assert.Equal(SetOperator.Except, set.Operator);
+        Assert.True(set.IsRecursive);
+        Assert.Equal(2, set.OrderBy!.Count);
+        Assert.IsType<ParameterExpression>(set.Limit);
+        Assert.Contains("UNION ALL", set.ToSql());
+        Assert.Contains("INTERSECT", set.ToSql());
+        Assert.Contains("EXCEPT", set.ToSql());
+
+        var grouped = Sql.Values(1)
+            .Limit(1)
+            .Union(Sql.Values(2).Build())
+            .ToSql();
+        Assert.StartsWith("(VALUES (1) LIMIT 1) UNION", grouped);
+
+        var nestedCtes = Sql.Select("id")
+            .From("source")
+            .With("inner_cte", Sql.Select("id").From("inner_source").Build())
+            .Union(Sql.Select("id").From("other"))
+            .With("outer_cte", Sql.Select("id").From("outer_source").Build())
+            .ToSql();
+        Assert.DoesNotContain(") WITH inner_cte", nestedCtes);
+        Assert.Contains("(WITH inner_cte", nestedCtes);
+
+        var explain = Sql.Explain(set)
+            .Analyze()
+            .Parenthesized()
+            .Build();
+
+        Assert.True(explain.Analyze);
+        Assert.True(explain.IsQueryParenthesized);
+    }
+
+    [Fact]
+    public void Dml_builders_cover_sources_returning_into_and_merge()
+    {
+        var source = Sql.Select("id", "name").From("incoming").Build();
+        var insert = Sql.InsertInto("users")
+            .Columns("id", "name")
+            .From(source)
+            .Returning(Sql.Col("id"))
+            .ReturningInto(Sql.Param("inserted_id"))
+            .Build();
+        var update = Sql.Update("users", "u")
+            .Set("name", Sql.Col("i.name"))
+            .From(source, "i")
+            .Where(Sql.Col("u.id").EqualTo(Sql.Col("i.id")))
+            .Returning(Sql.Col("u.id"))
+            .ReturningInto(Sql.Param("updated_id"))
+            .Build();
+        var delete = Sql.DeleteFrom("users", "u")
+            .Using("expired", "e")
+            .Where(Sql.Col("u.id").EqualTo(Sql.Col("e.id")))
+            .Returning(Sql.Col("u.id"))
+            .ReturningInto(Sql.Param("deleted_id"))
+            .Build();
+        var merge = Sql.MergeInto("users", "u")
+            .Using("incoming", "i")
+            .On(Sql.Col("u.id").EqualTo(Sql.Col("i.id")))
+            .WhenMatchedUpdate(
+                condition: null,
+                deleteWhere: Sql.Col("i.deleted").EqualTo(Sql.Lit(true)),
+                Sql.Assign("name", Sql.Col("i.name")))
+            .WhenNotMatchedInsert(["id", "name"], Sql.Col("i.id"), Sql.Col("i.name"))
+            .WhenNotMatchedBySourceDelete(Sql.Col("u.inactive").EqualTo(Sql.Lit(true)))
+            .Returning(Sql.Col("u.id"))
+            .Build();
+
+        Assert.NotNull(insert.ReturningInto);
+        Assert.IsType<DerivedTable>(update.From);
+        Assert.IsType<NamedTable>(delete.Using);
+        Assert.Equal(3, merge.WhenClauses.Count);
+        Assert.NotNull(Assert.IsType<MergeUpdateAction>(merge.WhenClauses[0].Action).DeleteWhere);
+        Assert.Contains("MERGE INTO users AS u", merge.ToSql());
+        Assert.Contains("WHEN NOT MATCHED BY SOURCE", merge.ToSql());
+    }
+
+    [Fact]
+    public void Ddl_builders_cover_every_supported_statement()
+    {
+        var createTable = Sql.CreateTable("users")
+            .Temporary()
+            .IfNotExists()
+            .Column(Sql.DefineColumn(
+                "id",
+                new SqlDataType("INT"),
+                Nullability.NotNull,
+                identity: IdentityGeneration.Always,
+                primaryKey: true))
+            .Column("name", "VARCHAR", 100)
+            .Constraint(Sql.Unique(["name"], "uq_users_name"))
+            .Build();
+        var alterTable = Sql.AlterTable("users")
+            .AddColumn("email", "VARCHAR", 200)
+            .AlterColumn("name", nullability: Nullability.NotNull)
+            .AddConstraint(Sql.Check(Sql.Col("id").GreaterThan(Sql.Lit(0)), "ck_users_id"))
+            .RenameColumn("email", "email_address")
+            .Build();
+        var drop = Sql.DropTable("users").And("archived_users").IfExists().Cascade().Build();
+        var truncate = Sql.Truncate("users").And("audit").RestartIdentity().Cascade().Build();
+        var view = Sql.CreateView("active_users")
+            .OrReplace()
+            .Columns("id")
+            .As(Sql.Select("id").From("users").Build())
+            .Build();
+        var index = Sql.CreateIndex("ix_users_name", "users")
+            .Unique()
+            .IfNotExists()
+            .Column("name", OrderDirection.Descending, NullOrder.Last)
+            .Where(Sql.Col("name").IsNotNull())
+            .Build();
+        var createSequence = Sql.CreateSequence("user_ids")
+            .IfNotExists()
+            .StartWith(1)
+            .IncrementBy(2)
+            .MinValue(1)
+            .MaxValue(1000)
+            .Cache(20)
+            .Cycle(false)
+            .Build();
+        var alterSequence = Sql.AlterSequence("user_ids")
+            .IncrementBy(5)
+            .Cycle()
+            .Build();
+
+        Assert.Contains("CREATE TEMPORARY TABLE IF NOT EXISTS users", createTable.ToSql());
+        Assert.Equal(4, alterTable.Actions.Count);
+        Assert.Equal(2, drop.Names.Count);
+        Assert.True(truncate.RestartIdentity);
+        Assert.True(view.OrReplace);
+        Assert.True(index.IsUnique);
+        Assert.False(createSequence.Options.Cycle);
+        Assert.True(alterSequence.Options.Cycle);
+    }
+
+    [Fact]
+    public void New_builders_reject_incomplete_statements()
+    {
+        Assert.Throws<InvalidOperationException>(() => Sql.CreateTable("empty").Build());
+        Assert.Throws<InvalidOperationException>(() => Sql.AlterTable("users").Build());
+        Assert.Throws<InvalidOperationException>(() => Sql.CreateView("users_view").Build());
+        Assert.Throws<InvalidOperationException>(() => Sql.CreateIndex("ix", "users").Build());
+        Assert.Throws<InvalidOperationException>(() => Sql.AlterSequence("sequence").Build());
+        Assert.Throws<InvalidOperationException>(() => Sql.MergeInto("users").Build());
+        Assert.Throws<ArgumentException>(() => Sql.Values(1).Row(2, 3));
+        Assert.Throws<ArgumentException>(() => Sql.InsertInto("users").Values(1).Values(2, 3));
+        Assert.Throws<ArgumentException>(() => Sql.InsertInto("users").Values(1).Columns("a", "b"));
+        Assert.Throws<ArgumentException>(() => Sql.InsertInto("users").Values());
+        Assert.Throws<ArgumentException>(() => Sql.AlterTable("users").AlterColumn("name"));
+        Assert.Throws<ArgumentException>(() =>
+            Sql.AlterTable("users").AlterColumn(
+                "name",
+                new SqlDataType("VARCHAR", 100),
+                Nullability.NotNull));
+        Assert.Throws<ArgumentException>(() => Sql.PrimaryKey([]));
+        Assert.Throws<ArgumentException>(() =>
+            Sql.ForeignKey(["tenant_id", "id"], "parent", ["id"]));
+        Assert.Throws<InvalidOperationException>(() =>
+            Sql.Select("id").Limit(5).Top(10, percent: true));
+        Assert.Throws<InvalidOperationException>(() =>
+            Sql.Select("id").Top(10, percent: true).Limit(5));
+        Assert.Throws<InvalidOperationException>(() =>
+            Sql.Select("id").Offset(5).Top(10, percent: true));
+        Assert.Throws<InvalidOperationException>(() =>
+            Sql.Select("id").Top(10, percent: true).Offset(5));
+        Assert.Throws<InvalidOperationException>(() =>
+            Sql.Select("id").Top(10, percent: false, withTies: true).Build());
+        Assert.Throws<ArgumentException>(() =>
+            Sql.DefineColumn(
+                "id",
+                new SqlDataType("INT"),
+                defaultValue: Sql.Lit(1),
+                identity: IdentityGeneration.Always));
+        Assert.Throws<InvalidOperationException>(() =>
+            Sql.InsertInto("users").Values(1).ReturningInto(Sql.Param("id")).Build());
+        Assert.Throws<InvalidOperationException>(() =>
+            Sql.Update("users")
+                .Set("name", "Ada")
+                .Returning(Sql.Col("id"), Sql.Col("name"))
+                .ReturningInto(Sql.Param("id"))
+                .Build());
+        Assert.Throws<ArgumentException>(() =>
+            Sql.Frame(
+                WindowFrameUnit.Rows,
+                Sql.UnboundedFollowing(),
+                Sql.CurrentRow()));
+        Assert.Throws<ArgumentException>(() =>
+            Sql.Frame(
+                WindowFrameUnit.Rows,
+                Sql.CurrentRow(),
+                Sql.UnboundedPreceding()));
+        Assert.Throws<NotSupportedException>(() =>
+            Sql.Values(1)
+                .Limit(1)
+                .Union(Sql.Values(2).Build())
+                .ToSql(SqlDialects.Sqlite));
+        Assert.Throws<ArgumentException>(() =>
+            Sql.MergeInto("users")
+                .Using("source")
+                .On(Sql.Lit(true))
+                .WhenNotMatchedInsert(["id"], 1, 2));
+        Assert.Throws<ArgumentException>(() => Sql.Document());
+        Assert.Throws<ArgumentException>(() => Sql.Row());
+        Assert.Throws<ArgumentException>(() => Sql.Interval(true, "DAY"));
+        Assert.Throws<ArgumentException>(() => Sql.Interval(double.NaN, "DAY"));
+        Assert.Throws<ArgumentException>(() => Sql.Interval(double.PositiveInfinity, "DAY"));
+        Assert.Throws<ArgumentException>(() => Sql.Lit(double.NaN));
+        Assert.Throws<ArgumentException>(() => Sql.Lit(float.NegativeInfinity));
+        Assert.Throws<ArgumentException>(() => Sql.Lit(1e100));
+        Assert.Throws<ArgumentException>(() => Sql.Lit(Guid.NewGuid()));
+        Assert.Throws<ArgumentException>(() => Sql.Lit(TimeSpan.FromMinutes(1)));
+        Assert.Throws<ArgumentException>(() => Sql.Interval(1e100, "SECOND"));
+        Assert.Throws<ArgumentException>(() => Sql.Col("id").In());
+        Assert.Throws<ArgumentException>(() => Sql.Col("id").NotIn());
+        Assert.Throws<ArgumentException>(() => Sql.Star("catalog.schema.table"));
+    }
+
+    private static void AssertParseable(string name, SqlNode node, SqlDialect dialect)
+    {
+        var sql = node.ToSql(dialect);
+        var parsed = dialect.TryParse(sql, out _, out var error);
+        Assert.True(parsed, $"{name} generated SQL that {dialect.Name} cannot parse: {sql}{Environment.NewLine}{error}");
+    }
+}


### PR DESCRIPTION
Cyqwel's AST and SQL generator supported substantially more syntax than the fluent builder exposed, while some constructible forms could not be parsed back by any built-in dialect. This aligns the builder surface with the supported SQL model and makes parser ownership an explicit invariant.

## Summary

- add fluent coverage for advanced CTEs, set operations, values, windows, joins, hierarchy, explain, mutation sources, merge, returning, and supported DDL statements
- close parser and generator gaps needed for simple CASE, named windows, grouped set operands, foreign-key actions, truncate identity options, and drop schema
- validate builder inputs so unsupported or structurally invalid SQL cannot be produced through fluent helpers
- add a cross-family builder-to-parser catalog covering Generic, T-SQL, MySQL, and dialect-specific restrictions

Manual AST construction remains available as an escape hatch; the parseability guarantee applies to the public builder helpers.