### PR TITLE
Configure .NET 8 SDK feature band

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,4 +1,9 @@
 {
+  "sdk": {
+    "version": "8.0.400",
+    "rollForward": "latestPatch",
+    "allowPrerelease": false
+  },
   "test": {
     "runner": "Microsoft.Testing.Platform"
   }


### PR DESCRIPTION
The repository currently leaves SDK selection implicit even though both projects target .NET 8. Configure a stable minimum feature band so local and CI commands select an installed .NET 8.0.4xx SDK consistently.

The SDK policy starts at 8.0.400, rolls forward to the latest patch within that feature band, and excludes preview SDKs. The existing Microsoft.Testing.Platform configuration is preserved.