### PR TITLE
Add parser support for regression cases

### DIFF
--- a/src/Cyqwel/Ast/Clauses.cs
+++ b/src/Cyqwel/Ast/Clauses.cs
@@ -33,6 +33,8 @@ public enum JoinKind
     Right,
     Full,
     Cross,
+    OuterApply,
+    CrossApply,
 }
 
 public enum JoinSyntax

--- a/src/Cyqwel/Ast/Ddl.cs
+++ b/src/Cyqwel/Ast/Ddl.cs
@@ -38,6 +38,12 @@ public abstract record TableConstraint : TableElement
     public SqlIdentifier? Name { get; init; }
 }
 
+public sealed record IndexTableElement(
+    SqlIdentifier? Name,
+    IReadOnlyList<IndexColumn> Columns,
+    bool IsUnique = false,
+    bool IsKey = false) : TableElement;
+
 public sealed record PrimaryKeyConstraint(
     IReadOnlyList<SqlIdentifier> Columns) : TableConstraint
 {

--- a/src/Cyqwel/Ast/Expressions.cs
+++ b/src/Cyqwel/Ast/Expressions.cs
@@ -28,6 +28,24 @@ public sealed record StarExpression(IReadOnlyList<SqlIdentifier>? Qualifier = nu
 
 public sealed record LiteralExpression(object? Value) : SqlExpression;
 
+public enum TrimDirection
+{
+    Leading,
+    Trailing,
+    Both,
+}
+
+public sealed record TrimExpression(
+    TrimDirection Direction,
+    SqlExpression? Character,
+    SqlExpression Source) : SqlExpression;
+
+public sealed record TypedLiteralExpression(
+    SqlIdentifier TypeName,
+    SqlExpression Value) : SqlExpression;
+
+public sealed record HexLiteralExpression(string Value) : SqlExpression;
+
 public sealed record ParameterExpression(
     string Name,
     char Prefix = '@',

--- a/src/Cyqwel/Ast/Statements.cs
+++ b/src/Cyqwel/Ast/Statements.cs
@@ -81,3 +81,11 @@ public sealed record MergeStatement(
     IReadOnlyList<MergeWhenClause> WhenClauses,
     IReadOnlyList<SqlExpression>? Returning = null,
     IReadOnlyList<SqlExpression>? ReturningInto = null) : SqlStatement;
+
+public sealed record GrantStatement(
+    IReadOnlyList<SqlIdentifier> Objects,
+    IReadOnlyList<SqlIdentifier> Grantees) : SqlStatement;
+
+public sealed record SetStatement(
+    IReadOnlyList<SqlIdentifier> Keywords,
+    IReadOnlyList<SqlNode> Arguments) : SqlStatement;

--- a/src/Cyqwel/Generation/SqlGenerator.Standard.cs
+++ b/src/Cyqwel/Generation/SqlGenerator.Standard.cs
@@ -150,11 +150,50 @@ public sealed partial class SqlGenerator
             case ColumnDefinition column:
                 WriteColumnDefinition(column);
                 break;
+            case IndexTableElement index:
+                WriteIndexTableElement(index);
+                break;
             case TableConstraint constraint:
                 WriteTableConstraint(constraint);
                 break;
             default:
                 throw new NotSupportedException($"Unsupported table element '{element.GetType().Name}'.");
+        }
+    }
+
+    private void WriteIndexTableElement(IndexTableElement index)
+    {
+        if (index.IsUnique)
+        {
+            Keyword("UNIQUE");
+            Space();
+        }
+
+        Keyword(index.IsKey ? "KEY" : "INDEX");
+        if (index.Name is not null)
+        {
+            Space();
+            WriteIdentifier(index.Name);
+        }
+
+        _builder.Append(" (");
+        WriteSeparated(index.Columns, WriteIndexColumn);
+        _builder.Append(')');
+    }
+
+    private void WriteIndexColumn(IndexColumn column)
+    {
+        WriteExpression(column.Expression);
+        if (column.Direction != OrderDirection.Unspecified)
+        {
+            Space();
+            Keyword(column.Direction == OrderDirection.Ascending ? "ASC" : "DESC");
+        }
+
+        if (column.NullOrder != NullOrder.Unspecified)
+        {
+            Space();
+            Keyword(column.NullOrder == NullOrder.First ? "NULLS FIRST" : "NULLS LAST");
         }
     }
 

--- a/src/Cyqwel/Generation/SqlGenerator.cs
+++ b/src/Cyqwel/Generation/SqlGenerator.cs
@@ -50,6 +50,8 @@ public sealed partial class SqlGenerator
             case UpdateStatement value: WriteUpdate(value); break;
             case DeleteStatement value: WriteDelete(value); break;
             case MergeStatement value: WriteMerge(value); break;
+            case GrantStatement value: WriteGrant(value); break;
+            case SetStatement value: WriteSet(value); break;
             case CreateTableStatement value: WriteCreateTable(value); break;
             case AlterTableStatement value: WriteAlterTable(value); break;
             case DropStatement value: WriteDrop(value); break;
@@ -361,6 +363,29 @@ public sealed partial class SqlGenerator
         WriteReturning(update.Returning, update.ReturningInto);
     }
 
+    private void WriteGrant(GrantStatement grant)
+    {
+        Keyword("GRANT");
+        Space();
+        WriteSeparated(grant.Objects, WriteIdentifier);
+        Space();
+        Keyword("TO");
+        Space();
+        WriteSeparated(grant.Grantees, WriteIdentifier);
+    }
+
+    private void WriteSet(SetStatement set)
+    {
+        Keyword("SET");
+        Space();
+        WriteSeparated(set.Keywords, WriteIdentifier, " ");
+        foreach (var argument in set.Arguments)
+        {
+            Space();
+            WriteSetArgument(argument);
+        }
+    }
+
     private void WriteDelete(DeleteStatement delete)
     {
         Keyword("DELETE FROM");
@@ -628,6 +653,8 @@ public sealed partial class SqlGenerator
                     JoinKind.Right => "RIGHT JOIN",
                     JoinKind.Full => "FULL JOIN",
                     JoinKind.Cross => "CROSS JOIN",
+                    JoinKind.OuterApply => "OUTER APPLY",
+                    JoinKind.CrossApply => "CROSS APPLY",
                     _ => throw new ArgumentOutOfRangeException(),
                 });
                 Space();
@@ -691,6 +718,17 @@ public sealed partial class SqlGenerator
                 break;
             case LiteralExpression literal:
                 WriteLiteral(literal);
+                break;
+            case TrimExpression trim:
+                WriteTrim(trim);
+                break;
+            case TypedLiteralExpression typed:
+                WriteIdentifier(typed.TypeName);
+                Space();
+                WriteExpression(typed.Value);
+                break;
+            case HexLiteralExpression hex:
+                _builder.Append(hex.Value);
                 break;
             case ParameterExpression parameter:
                 WriteParameter(parameter);
@@ -1143,6 +1181,50 @@ public sealed partial class SqlGenerator
         }
 
         _builder.Append(parameter.Prefix).Append(parameter.Name);
+    }
+
+    private void WriteTrim(TrimExpression trim)
+    {
+        Keyword("TRIM");
+        _builder.Append('(');
+        if (trim.Direction != TrimDirection.Both)
+        {
+            Keyword(trim.Direction == TrimDirection.Leading ? "LEADING" : "TRAILING");
+            Space();
+        }
+
+        if (trim.Character is not null || trim.Direction != TrimDirection.Both)
+        {
+            if (trim.Character is not null)
+            {
+                WriteExpression(trim.Character);
+                Space();
+            }
+
+            Keyword("FROM");
+            Space();
+        }
+
+        WriteExpression(trim.Source);
+        _builder.Append(')');
+    }
+
+    private void WriteSetArgument(SqlNode node)
+    {
+        switch (node)
+        {
+            case SqlIdentifier identifier:
+                WriteIdentifier(identifier);
+                break;
+            case TableName tableName:
+                WriteTableName(tableName);
+                break;
+            case SqlExpression expression:
+                WriteExpression(expression);
+                break;
+            default:
+                throw new NotSupportedException($"Unsupported set argument '{node.GetType().Name}'.");
+        }
     }
 
     private void WriteLiteral(LiteralExpression literal)

--- a/src/Cyqwel/Parsing/SqlParser.cs
+++ b/src/Cyqwel/Parsing/SqlParser.cs
@@ -177,6 +177,17 @@ public static class SqlParser
         var ZONE = Keyword("ZONE");
         var LONG = Keyword("LONG");
         var RAW = Keyword("RAW");
+        var GRANT = Keyword("GRANT");
+        var SESSION = Keyword("SESSION");
+        var AUTHORIZATION = Keyword("AUTHORIZATION");
+        var IDENTITY_INSERT = Keyword("IDENTITY_INSERT");
+        var STATISTICS = Keyword("STATISTICS");
+        var TRIM = Keyword("TRIM");
+        var LEADING = Keyword("LEADING");
+        var TRAILING = Keyword("TRAILING");
+        var BOTH = Keyword("BOTH");
+        var APPLY = Keyword("APPLY");
+        var TIMESTAMPTZ = Keyword("TIMESTAMPTZ");
 
         var reservedWords = CreateReservedWords(syntax);
 
@@ -208,9 +219,11 @@ public static class SqlParser
         identifierParsers.Add(unquotedIdentifier);
         var simpleIdentifier = OneOf(identifierParsers.ToArray());
         var nonKeywordIdentifier = simpleIdentifier;
+        var tableIdentifier = simpleIdentifier.Or(TABLE.Then(new SqlIdentifier("TABLE")));
         var identifierParts = Separated(dot, simpleIdentifier);
+        var tableIdentifierParts = Separated(dot, tableIdentifier);
 
-        var tableName = identifierParts.Then(parts => new TableName(parts));
+        var tableName = tableIdentifierParts.Then(parts => new TableName(parts));
         var column = identifierParts.Then<SqlExpression>(parts =>
         {
             if (parts.Count > 1
@@ -414,6 +427,31 @@ public static class SqlParser
         var starExpression = star.Then<SqlExpression>(new StarExpression());
 
         var defaultExpression = DEFAULT.Then<SqlExpression>(new DefaultExpression());
+        var stringLiteralWithIntroducer = simpleIdentifier
+            .And(text)
+            .Then<SqlExpression>(value => new LiteralExpression(((LiteralExpression)value.Item2).Value));
+        var typedLiteral = TIMESTAMPTZ.SkipAnd(text)
+            .Then<SqlExpression>(value => new TypedLiteralExpression(new SqlIdentifier("TIMESTAMPTZ"), value));
+        var hexLiteral = Terms.Text("0x")
+            .Or(Terms.Text("0X"))
+            .Then(value => value.ToString())
+            .And(Literals.AnyOf(Character.HexDigits, 1, int.MaxValue)
+                .Then(span => span.ToString()))
+            .Then<SqlExpression>(value => new HexLiteralExpression($"{value.Item1}{value.Item2}"));
+        var trimSpecial = TRIM.SkipAnd(leftParenthesis)
+            .And(LEADING.Then(TrimDirection.Leading)
+                .Or(TRAILING.Then(TrimDirection.Trailing))
+                .Or(BOTH.Then(TrimDirection.Both))
+                .Optional())
+            .And(stringLiteralWithIntroducer.Or(expression).Optional())
+            .AndSkip(FROM)
+            .And(expression)
+            .AndSkip(rightParenthesis)
+            .Then<SqlExpression>(value => new TrimExpression(
+                value.Item2.HasValue ? value.Item2.Value : TrimDirection.Both,
+                value.Item3.HasValue ? value.Item3.Value : null,
+                value.Item4));
+        var trim = trimSpecial.Or(function);
         var term = tryCast
             .Or(cast)
             .Or(extract)
@@ -421,7 +459,7 @@ public static class SqlParser
             .Or(caseExpression)
             .Or(exists)
             .Or(subquery)
-            .Or(function)
+            .Or(trim)
             .Or(row)
             .Or(grouped)
             .Or(qualifiedStar)
@@ -430,6 +468,8 @@ public static class SqlParser
             .Or(boolean)
             .Or(nullLiteral)
             .Or(defaultExpression)
+            .Or(typedLiteral)
+            .Or(hexLiteral)
             .Or(text)
             .Or(number)
             .Or(column);
@@ -635,15 +675,16 @@ public static class SqlParser
                 null));
         windowSpecification.Parser = namedWindowSpecification.Or(anonymousWindowSpecification);
 
-        var alias = AS.SkipAnd(simpleIdentifier).Or(nonKeywordIdentifier);
+        var stringAlias = text.Then(value => new SqlIdentifier(((LiteralExpression)value).Value?.ToString() ?? string.Empty));
+        var alias = AS.SkipAnd(simpleIdentifier.Or(stringAlias)).Or(nonKeywordIdentifier.Or(stringAlias));
         var tableAlias = syntax.SupportsTableAliasAs
             ? alias
-            : nonKeywordIdentifier;
+            : nonKeywordIdentifier.Or(stringAlias);
         var selectItem = expression.And(alias.Optional())
             .Then(value => new SelectItem(
                 value.Item1,
-                value.Item2.HasValue ? value.Item2.Value : null));
-        var projections = Separated(comma, selectItem);
+                value.Item2.HasValue ? (SqlIdentifier?)value.Item2.Value : null));
+        var projections = Separated<char, SelectItem>(comma, selectItem);
 
         var derivedTable = Between(leftParenthesis, query, rightParenthesis)
             .And(tableAlias)
@@ -651,13 +692,15 @@ public static class SqlParser
         var namedTable = tableName.And(tableAlias.Optional())
             .Then<TableSource>(value => new NamedTable(
                 value.Item1,
-                value.Item2.HasValue ? value.Item2.Value : null));
+                value.Item2.HasValue ? (SqlIdentifier?)value.Item2.Value : null));
         var tablePrimary = derivedTable.Or(namedTable);
 
         var joinKind = LEFT.AndSkip(OUTER.Optional()).AndSkip(JOIN).Then(JoinKind.Left)
             .Or(RIGHT.AndSkip(OUTER.Optional()).AndSkip(JOIN).Then(JoinKind.Right))
             .Or(FULL.AndSkip(OUTER.Optional()).AndSkip(JOIN).Then(JoinKind.Full))
             .Or(CROSS.AndSkip(JOIN).Then(JoinKind.Cross))
+            .Or(CROSS.AndSkip(APPLY).Then(JoinKind.CrossApply))
+            .Or(OUTER.AndSkip(APPLY).Then(JoinKind.OuterApply))
             .Or(INNER.AndSkip(JOIN).Then(JoinKind.Inner))
             .Or(JOIN.Then(JoinKind.Inner));
         var joinCondition = ON.SkipAnd(expression)
@@ -885,6 +928,37 @@ public static class SqlParser
                 .Then<ParsedReturning?>(value => value)
                 .Or(Always<ParsedReturning?>(null))
             : Always<ParsedReturning?>(null);
+        var grant = GRANT.SkipAnd(Separated(comma, simpleIdentifier))
+            .AndSkip(TO)
+            .And(Separated(comma, simpleIdentifier))
+            .Then<SqlStatement>(value => new GrantStatement(value.Item1, value.Item2));
+        var setSessionAuthorization = SET
+            .And(LOCAL.Optional())
+            .Then(value => new ParsedSetSessionAuthorizationState(value.Item2.HasValue))
+            .And(SESSION)
+            .Then(value => new ParsedSetSessionAuthorizationState(value.Item1.HasLocal))
+            .And(AUTHORIZATION)
+            .Then(value => new ParsedSetSessionAuthorizationState(value.Item1.HasLocal))
+            .And(simpleIdentifier)
+            .Then<SqlStatement>(value => new SetStatement(
+                value.Item1.HasLocal
+                    ? [new SqlIdentifier("LOCAL"), new SqlIdentifier("SESSION"), new SqlIdentifier("AUTHORIZATION")]
+                    : [new SqlIdentifier("SESSION"), new SqlIdentifier("AUTHORIZATION")],
+                [value.Item2]));
+        var setIdentityInsert = SET.SkipAnd(IDENTITY_INSERT)
+            .And(tableName)
+            .Then(value => new ParsedSetIdentityInsertState(value.Item2))
+            .And(ON.Then(new SqlIdentifier("ON")).Or(OFF.Then(new SqlIdentifier("OFF"))))
+            .Then<SqlStatement>(value => new SetStatement(
+                [new SqlIdentifier("IDENTITY_INSERT")],
+                [value.Item1.TableName, value.Item2]));
+        var setStatistics = SET.SkipAnd(STATISTICS)
+            .And(TIME.Then(new SqlIdentifier("TIME")))
+            .Then(value => new ParsedSetStatisticsState(value.Item2))
+            .And(ON.Then(new SqlIdentifier("ON")).Or(OFF.Then(new SqlIdentifier("OFF"))))
+            .Then<SqlStatement>(value => new SetStatement(
+                [new SqlIdentifier("STATISTICS"), value.Item1.Time],
+                [value.Item2]));
         var insertColumns = Between(leftParenthesis, Separated(comma, simpleIdentifier), rightParenthesis);
         var insertValues = VALUES.SkipAnd(Separated(comma, valueRow));
         var insert = INSERT.SkipAnd(INTO)
@@ -1064,6 +1138,11 @@ public static class SqlParser
                     isUnique);
             });
 
+        var indexColumn = expression.And(orderDirection.Optional()).And(nullOrder.Optional())
+            .Then(value => new IndexColumn(
+                value.Item1,
+                value.Item2.HasValue ? value.Item2.Value : OrderDirection.Unspecified,
+                value.Item3.HasValue ? value.Item3.Value : NullOrder.Unspecified));
         var identifierList = Between(
             leftParenthesis,
             Separated(comma, simpleIdentifier),
@@ -1105,11 +1184,22 @@ public static class SqlParser
             .Then<TableConstraint>(value => new CheckConstraint(
                 value.Item2,
                 value.Item1.HasValue ? value.Item1.Value : null));
+        var indexTableElement = constraintName
+            .And(UNIQUE.Optional())
+            .And(KEY.Then(true).Or(INDEX.Then(false)))
+            .And(simpleIdentifier.Optional())
+            .And(Between(leftParenthesis, Separated(comma, indexColumn), rightParenthesis))
+            .Then<TableElement>(value => new IndexTableElement(
+                value.Item4.HasValue ? value.Item4.Value : null,
+                value.Item5,
+                value.Item2.HasValue,
+                value.Item3));
         var tableConstraint = primaryKeyConstraint
             .Or(uniqueConstraint)
             .Or(foreignKeyConstraint)
             .Or(checkConstraint);
-        var tableElement = tableConstraint.Then<TableElement>(value => value)
+        var tableElement = indexTableElement
+            .Or(tableConstraint.Then<TableElement>(value => value))
             .Or(columnDefinition.Then<TableElement>(value => value));
         var tableElements = Between(
             leftParenthesis,
@@ -1157,11 +1247,6 @@ public static class SqlParser
                 value.Item2.HasValue,
                 value.Item3.HasValue ? value.Item3.Value : null));
 
-        var indexColumn = expression.And(orderDirection.Optional()).And(nullOrder.Optional())
-            .Then(value => new IndexColumn(
-                value.Item1,
-                value.Item2.HasValue ? value.Item2.Value : OrderDirection.Unspecified,
-                value.Item3.HasValue ? value.Item3.Value : NullOrder.Unspecified));
         var createIndex = CREATE.SkipAnd(UNIQUE.Optional())
             .AndSkip(INDEX)
             .And(ifNotExists)
@@ -1346,8 +1431,13 @@ public static class SqlParser
             explain = Fail<SqlStatement>();
         }
 
+        var setStatement = setSessionAuthorization
+            .Or(setIdentityInsert)
+            .Or(setStatistics);
         var statement = explain
             .Or(query.Then<SqlStatement>(value => value))
+            .Or(grant)
+            .Or(setStatement)
             .Or(insert)
             .Or(update)
             .Or(delete)
@@ -1360,7 +1450,7 @@ public static class SqlParser
             .Or(alterTable)
             .Or(dropStatement)
             .Or(truncateStatement);
-        var document = Separated(semicolon, statement)
+        var document = Separated<char, SqlStatement>(semicolon, statement)
             .AndSkip(semicolon.Optional())
             .Then(statements => new SqlDocument(statements))
             .AndSkip(Terms.WhiteSpace().Optional())
@@ -1536,6 +1626,14 @@ public static class SqlParser
 
         return words;
     }
+
+    private readonly record struct ParsedHexLiteralState(char Prefix, object? Value);
+
+    private readonly record struct ParsedSetSessionAuthorizationState(bool HasLocal);
+
+    private readonly record struct ParsedSetIdentityInsertState(TableName TableName);
+
+    private readonly record struct ParsedSetStatisticsState(SqlIdentifier Time);
 
     private sealed record ParsedDataTypeArguments(
         IReadOnlyList<int> Arguments,

--- a/src/Cyqwel/Visitors/SqlNodeChildren.Standard.cs
+++ b/src/Cyqwel/Visitors/SqlNodeChildren.Standard.cs
@@ -93,6 +93,12 @@ internal static partial class SqlNodeChildren
         if (node.GeneratedExpression is not null) yield return node.GeneratedExpression;
     }
 
+    private static IEnumerable<SqlNode> IndexTableElementChildren(IndexTableElement node)
+    {
+        if (node.Name is not null) yield return node.Name;
+        foreach (var column in node.Columns) yield return column;
+    }
+
     private static IEnumerable<SqlNode> ConstraintChildren(
         SqlIdentifier? name,
         IReadOnlyList<SqlIdentifier> columns)

--- a/src/Cyqwel/Visitors/SqlNodeChildren.cs
+++ b/src/Cyqwel/Visitors/SqlNodeChildren.cs
@@ -26,6 +26,10 @@ internal static partial class SqlNodeChildren
                 return DeleteChildren(value);
             case MergeStatement value:
                 return MergeChildren(value);
+            case GrantStatement value:
+                return GrantChildren(value);
+            case SetStatement value:
+                return SetChildren(value);
             case CreateTableStatement value:
                 return CreateTableChildren(value);
             case AlterTableStatement value:
@@ -130,6 +134,8 @@ internal static partial class SqlNodeChildren
                     : [.. value.Columns, .. value.Values];
             case ColumnDefinition value:
                 return ColumnDefinitionChildren(value);
+            case IndexTableElement value:
+                return IndexTableElementChildren(value);
             case PrimaryKeyConstraint value:
                 return ConstraintChildren(value.Name, value.Columns);
             case UniqueConstraint value:
@@ -161,6 +167,12 @@ internal static partial class SqlNodeChildren
             case DefaultExpression:
             case MergeDeleteAction:
                 return Array.Empty<SqlNode>();
+            case TrimExpression value:
+                return TrimChildren(value);
+            case TypedLiteralExpression value:
+                return TypedLiteralChildren(value);
+            case HexLiteralExpression value:
+                return HexLiteralChildren(value);
             case ParameterExpression value:
                 return value.DefaultValue is null
                     ? Array.Empty<SqlNode>()
@@ -353,5 +365,31 @@ internal static partial class SqlNodeChildren
         {
             foreach (var column in node.Using) yield return column;
         }
+    }
+
+    private static IEnumerable<SqlNode> TrimChildren(TrimExpression node)
+    {
+        if (node.Character is not null) yield return node.Character;
+        yield return node.Source;
+    }
+
+    private static IEnumerable<SqlNode> TypedLiteralChildren(TypedLiteralExpression node)
+    {
+        yield return node.TypeName;
+        yield return node.Value;
+    }
+
+    private static IEnumerable<SqlNode> HexLiteralChildren(HexLiteralExpression node) => Array.Empty<SqlNode>();
+
+    private static IEnumerable<SqlNode> GrantChildren(GrantStatement node)
+    {
+        foreach (var item in node.Objects) yield return item;
+        foreach (var item in node.Grantees) yield return item;
+    }
+
+    private static IEnumerable<SqlNode> SetChildren(SetStatement node)
+    {
+        foreach (var item in node.Keywords) yield return item;
+        foreach (var item in node.Arguments) yield return item;
     }
 }

--- a/src/Cyqwel/Visitors/SqlRewriter.Standard.cs
+++ b/src/Cyqwel/Visitors/SqlRewriter.Standard.cs
@@ -276,6 +276,16 @@ public abstract partial class SqlRewriter
                 };
     }
 
+    protected virtual SqlNode VisitIndexTableElement(IndexTableElement node)
+    {
+        var name = VisitOptional(node.Name);
+        var columns = VisitList(node.Columns);
+        return ReferenceEquals(name, node.Name)
+            && ReferenceEquals(columns, node.Columns)
+                ? node
+                : node with { Name = name, Columns = columns };
+    }
+
     protected virtual SqlNode VisitPrimaryKeyConstraint(PrimaryKeyConstraint node)
     {
         var columns = VisitList(node.Columns);

--- a/src/Cyqwel/Visitors/SqlRewriter.cs
+++ b/src/Cyqwel/Visitors/SqlRewriter.cs
@@ -22,6 +22,8 @@ public abstract partial class SqlRewriter
             UpdateStatement value => VisitUpdate(value),
             DeleteStatement value => VisitDelete(value),
             MergeStatement value => VisitMerge(value),
+            GrantStatement value => VisitGrant(value),
+            SetStatement value => VisitSet(value),
             CreateTableStatement value => VisitCreateTable(value),
             AlterTableStatement value => VisitAlterTable(value),
             DropStatement value => VisitDrop(value),
@@ -34,6 +36,9 @@ public abstract partial class SqlRewriter
             ColumnExpression value => VisitColumn(value),
             StarExpression value => VisitStar(value),
             LiteralExpression value => VisitLiteral(value),
+            TrimExpression value => VisitTrim(value),
+            TypedLiteralExpression value => VisitTypedLiteral(value),
+            HexLiteralExpression value => VisitHexLiteral(value),
             ParameterExpression value => VisitParameter(value),
             ParenthesizedExpression value => VisitParenthesized(value),
             UnaryExpression value => VisitUnary(value),
@@ -75,6 +80,7 @@ public abstract partial class SqlRewriter
             MergeInsertAction value => VisitMergeInsert(value),
             MergeDeleteAction value => VisitMergeDelete(value),
             ColumnDefinition value => VisitColumnDefinition(value),
+            IndexTableElement value => VisitIndexTableElement(value),
             PrimaryKeyConstraint value => VisitPrimaryKeyConstraint(value),
             UniqueConstraint value => VisitUniqueConstraint(value),
             ForeignKeyConstraint value => VisitForeignKeyConstraint(value),
@@ -236,7 +242,7 @@ public abstract partial class SqlRewriter
         var returning = VisitOptionalList(node.Returning);
         var returningInto = VisitOptionalList(node.ReturningInto);
         var usingSource = VisitOptional(node.Using);
-
+ 
         return ReferenceEquals(target, node.Target)
             && ReferenceEquals(where, node.Where)
             && ReferenceEquals(returning, node.Returning)
@@ -253,6 +259,24 @@ public abstract partial class SqlRewriter
                 };
     }
 
+    protected virtual SqlNode VisitGrant(GrantStatement node)
+    {
+        var objects = VisitOptionalList(node.Objects);
+        var grantees = VisitOptionalList(node.Grantees);
+        return ReferenceEquals(objects, node.Objects) && ReferenceEquals(grantees, node.Grantees)
+            ? node
+            : node with { Objects = objects, Grantees = grantees };
+    }
+
+    protected virtual SqlNode VisitSet(SetStatement node)
+    {
+        var keywords = VisitOptionalList(node.Keywords);
+        var arguments = VisitList(node.Arguments);
+        return ReferenceEquals(keywords, node.Keywords) && ReferenceEquals(arguments, node.Arguments)
+            ? node
+            : node with { Keywords = keywords, Arguments = arguments };
+    }
+ 
     protected virtual SqlNode VisitIdentifier(SqlIdentifier node) => node;
 
     protected virtual SqlNode VisitColumn(ColumnExpression node) =>
@@ -262,6 +286,26 @@ public abstract partial class SqlRewriter
         UpdateOptional(node, VisitOptionalList(node.Qualifier), node.Qualifier, static (n, qualifier) => n with { Qualifier = qualifier });
 
     protected virtual SqlNode VisitLiteral(LiteralExpression node) => node;
+    protected virtual SqlNode VisitTrim(TrimExpression node)
+    {
+        var character = VisitOptional(node.Character);
+        var source = Visit(node.Source);
+        return ReferenceEquals(character, node.Character) && ReferenceEquals(source, node.Source)
+            ? node
+            : node with { Character = character, Source = source };
+    }
+
+    protected virtual SqlNode VisitTypedLiteral(TypedLiteralExpression node)
+    {
+        var typeName = Visit(node.TypeName);
+        var value = Visit(node.Value);
+        return ReferenceEquals(typeName, node.TypeName) && ReferenceEquals(value, node.Value)
+            ? node
+            : node with { TypeName = typeName, Value = value };
+    }
+
+    protected virtual SqlNode VisitHexLiteral(HexLiteralExpression node) => node;
+
     protected virtual SqlNode VisitParameter(ParameterExpression node)
     {
         var defaultValue = VisitOptional(node.DefaultValue);

--- a/src/Cyqwel/Visitors/SqlVisitor.Standard.cs
+++ b/src/Cyqwel/Visitors/SqlVisitor.Standard.cs
@@ -32,6 +32,7 @@ public abstract partial class SqlVisitor
     protected virtual void VisitMergeInsert(MergeInsertAction node) => DefaultVisit(node);
     protected virtual void VisitMergeDelete(MergeDeleteAction node) => DefaultVisit(node);
     protected virtual void VisitColumnDefinition(ColumnDefinition node) => DefaultVisit(node);
+    protected virtual void VisitIndexTableElement(IndexTableElement node) => DefaultVisit(node);
     protected virtual void VisitPrimaryKeyConstraint(PrimaryKeyConstraint node) => DefaultVisit(node);
     protected virtual void VisitUniqueConstraint(UniqueConstraint node) => DefaultVisit(node);
     protected virtual void VisitForeignKeyConstraint(ForeignKeyConstraint node) => DefaultVisit(node);

--- a/src/Cyqwel/Visitors/SqlVisitor.cs
+++ b/src/Cyqwel/Visitors/SqlVisitor.cs
@@ -22,6 +22,8 @@ public abstract partial class SqlVisitor
             case UpdateStatement value: VisitUpdate(value); break;
             case DeleteStatement value: VisitDelete(value); break;
             case MergeStatement value: VisitMerge(value); break;
+            case GrantStatement value: VisitGrant(value); break;
+            case SetStatement value: VisitSet(value); break;
             case CreateTableStatement value: VisitCreateTable(value); break;
             case AlterTableStatement value: VisitAlterTable(value); break;
             case DropStatement value: VisitDrop(value); break;
@@ -34,6 +36,9 @@ public abstract partial class SqlVisitor
             case ColumnExpression value: VisitColumn(value); break;
             case StarExpression value: VisitStar(value); break;
             case LiteralExpression value: VisitLiteral(value); break;
+            case TrimExpression value: VisitTrim(value); break;
+            case TypedLiteralExpression value: VisitTypedLiteral(value); break;
+            case HexLiteralExpression value: VisitHexLiteral(value); break;
             case ParameterExpression value: VisitParameter(value); break;
             case ParenthesizedExpression value: VisitParenthesized(value); break;
             case UnaryExpression value: VisitUnary(value); break;
@@ -75,6 +80,7 @@ public abstract partial class SqlVisitor
             case MergeInsertAction value: VisitMergeInsert(value); break;
             case MergeDeleteAction value: VisitMergeDelete(value); break;
             case ColumnDefinition value: VisitColumnDefinition(value); break;
+            case IndexTableElement value: VisitIndexTableElement(value); break;
             case PrimaryKeyConstraint value: VisitPrimaryKeyConstraint(value); break;
             case UniqueConstraint value: VisitUniqueConstraint(value); break;
             case ForeignKeyConstraint value: VisitForeignKeyConstraint(value); break;
@@ -107,10 +113,15 @@ public abstract partial class SqlVisitor
     protected virtual void VisitInsert(InsertStatement node) => DefaultVisit(node);
     protected virtual void VisitUpdate(UpdateStatement node) => DefaultVisit(node);
     protected virtual void VisitDelete(DeleteStatement node) => DefaultVisit(node);
+    protected virtual void VisitGrant(GrantStatement node) => DefaultVisit(node);
+    protected virtual void VisitSet(SetStatement node) => DefaultVisit(node);
     protected virtual void VisitIdentifier(SqlIdentifier node) => DefaultVisit(node);
     protected virtual void VisitColumn(ColumnExpression node) => DefaultVisit(node);
     protected virtual void VisitStar(StarExpression node) => DefaultVisit(node);
     protected virtual void VisitLiteral(LiteralExpression node) => DefaultVisit(node);
+    protected virtual void VisitTrim(TrimExpression node) => DefaultVisit(node);
+    protected virtual void VisitTypedLiteral(TypedLiteralExpression node) => DefaultVisit(node);
+    protected virtual void VisitHexLiteral(HexLiteralExpression node) => DefaultVisit(node);
     protected virtual void VisitParameter(ParameterExpression node) => DefaultVisit(node);
     protected virtual void VisitParenthesized(ParenthesizedExpression node) => DefaultVisit(node);
     protected virtual void VisitUnary(UnaryExpression node) => DefaultVisit(node);

--- a/tests/Cyqwel.Tests/GenerationTests.cs
+++ b/tests/Cyqwel.Tests/GenerationTests.cs
@@ -43,6 +43,26 @@ public class GenerationTests
     }
 
     [Fact]
+    public void Generates_trim_direction_and_set_statements()
+    {
+        var trimDocument = SqlParser.Parse("SELECT TRIM(LEADING FROM name) FROM users");
+        var setDocument = SqlParser.Parse("SET LOCAL SESSION AUTHORIZATION abluva");
+
+        Assert.Equal("SELECT TRIM(LEADING FROM name) FROM users", trimDocument.ToSql());
+        Assert.Equal("SET LOCAL SESSION AUTHORIZATION abluva", setDocument.ToSql());
+    }
+
+    [Fact]
+    public void Generates_mysql_functional_index_table_elements()
+    {
+        var document = SqlParser.Parse("CREATE TABLE events (id INT, KEY idx_clean_batch ((TRIM(BOTH '0' FROM batch_no))))");
+
+        Assert.Equal(
+            "CREATE TABLE events (id INT, KEY idx_clean_batch ((TRIM('0' FROM batch_no))))",
+            document.ToSql());
+    }
+
+    [Fact]
     public void Generates_tsql_top_and_offset_fetch()
     {
         var top = Sql.Select("id").From("users").Limit(10).Build();

--- a/tests/Cyqwel.Tests/ParserTests.cs
+++ b/tests/Cyqwel.Tests/ParserTests.cs
@@ -105,6 +105,84 @@ public class ParserTests
     }
 
     [Fact]
+    public void Parses_grant_and_set_statements()
+    {
+        var document = SqlParser.Parse("GRANT abluva TO \"kk8529p@abluva.com\"; SET LOCAL SESSION AUTHORIZATION abluva; SET IDENTITY_INSERT dbo.Employees ON; SET STATISTICS TIME ON;");
+        var statements = document.Statements;
+ 
+        Assert.Collection(
+            statements,
+            statement =>
+            {
+                var grant = Assert.IsType<GrantStatement>(statement);
+                Assert.Equal("abluva", grant.Objects[0].Value);
+                Assert.Equal("kk8529p@abluva.com", grant.Grantees[0].Value);
+            },
+            statement =>
+            {
+                var set = Assert.IsType<SetStatement>(statement);
+                Assert.Equal("SESSION", set.Keywords[1].Value);
+                Assert.Equal("AUTHORIZATION", set.Keywords[2].Value);
+            },
+            statement =>
+            {
+                var set = Assert.IsType<SetStatement>(statement);
+                Assert.Equal("IDENTITY_INSERT", set.Keywords[0].Value);
+                var tableName = Assert.IsType<TableName>(set.Arguments[0]);
+                Assert.Equal("dbo", tableName.Parts[0].Value);
+                Assert.Equal("Employees", tableName.Parts[1].Value);
+                Assert.Equal("ON", Assert.IsType<SqlIdentifier>(set.Arguments[1]).Value);
+            },
+            statement =>
+            {
+                var set = Assert.IsType<SetStatement>(statement);
+                Assert.Equal("STATISTICS", set.Keywords[0].Value);
+                Assert.Equal("TIME", Assert.IsType<SqlIdentifier>(set.Keywords[1]).Value);
+                Assert.Equal("ON", Assert.IsType<SqlIdentifier>(set.Arguments[0]).Value);
+            });
+    }
+
+    [Fact]
+    public void Parses_apply_joins_and_special_expressions()
+    {
+        var document = SqlParser.Parse("SELECT trim(leading _utf8mb4'0' from batch_no), TIMESTAMPTZ '2026-04-10T00:00:00+00:00', 0x1 FROM events");
+        var select = Assert.IsType<SelectStatement>(Assert.Single(document.Statements));
+        var trim = Assert.IsType<TrimExpression>(Assert.IsType<SelectItem>(select.Projections[0]).Expression);
+        var typedLiteral = Assert.IsType<TypedLiteralExpression>(Assert.IsType<SelectItem>(select.Projections[1]).Expression);
+        var hexLiteral = Assert.IsType<HexLiteralExpression>(Assert.IsType<SelectItem>(select.Projections[2]).Expression);
+  
+        Assert.Equal(TrimDirection.Leading, trim.Direction);
+        Assert.Equal("0", Assert.IsType<string>(((LiteralExpression)trim.Character!).Value));
+        Assert.Equal("TIMESTAMPTZ", typedLiteral.TypeName.Value);
+        Assert.Equal("0x1", hexLiteral.Value);
+    }
+
+    [Fact]
+    public void Parses_mysql_functional_index_table_elements()
+    {
+        const string sql = "CREATE TABLE events (id INT, KEY idx_clean_batch ((TRIM(BOTH '0' FROM batch_no))))";
+        var document = SqlParser.Parse(sql);
+        var createTable = Assert.IsType<CreateTableStatement>(Assert.Single(document.Statements));
+        var index = Assert.Single(createTable.Elements.OfType<IndexTableElement>());
+        var column = Assert.Single(index.Columns);
+        var expression = Assert.IsType<ParenthesizedExpression>(column.Expression);
+        var trim = Assert.IsType<TrimExpression>(expression.Expression);
+
+        Assert.Equal("idx_clean_batch", index.Name!.Value);
+        Assert.Equal(TrimDirection.Both, trim.Direction);
+        Assert.Equal("0", Assert.IsType<string>(((LiteralExpression)trim.Character!).Value));
+    }
+
+    [Fact]
+    public void Rewriter_visits_grant_and_set_statements()
+    {
+        var document = SqlParser.Parse("GRANT abluva TO user; SET LOCAL SESSION AUTHORIZATION abluva");
+        var rewritten = new IdentityRewriter().Visit(document);
+
+        Assert.IsType<SqlDocument>(rewritten);
+    }
+
+    [Fact]
     public void Parses_window_functions_and_parameter_defaults()
     {
         var dialect = CreateParameterDefaultDialect();
@@ -458,4 +536,6 @@ public class ParserTests
         SqlDialectBuilder.Create($"parameter-defaults-{Guid.NewGuid():N}")
             .ConfigureParser(options => options with { SupportsParameterDefaults = true })
             .Build();
+
+    private sealed class IdentityRewriter : SqlRewriter;
 }


### PR DESCRIPTION
## Summary
This PR fixes a set of parser regressions that were causing Cyqwel to reject several SQL constructs from the reported issue cases. The work covers GRANT and SET statements, OUTER/CROSS APPLY joins, TRIM expressions, typed literals, hex literals, and MySQL-style functional index table elements.

## What changed
- Extended the Parlot-based grammar to recognize the new statement and expression forms.
- Added AST support and wired the new nodes through SQL generation and visitor/rewriter traversal so they round-trip correctly.
- Added regression tests for parsing and SQL generation of the new syntax.

## Validation
- dotnet test tests/Cyqwel.Tests/Cyqwel.Tests.csproj