### PR TITLE
Optimize conditional parser branches

### DIFF
--- a/src/Cyqwel/Parsing/SqlParser.cs
+++ b/src/Cyqwel/Parsing/SqlParser.cs
@@ -678,8 +678,7 @@ public static class SqlParser
                 .Then(value => (Start: value.Item1, End: (WindowFrameBound?)value.Item2))
                 .Or(windowFrameBound.Then(value => (Start: value, End: (WindowFrameBound?)null))))
             .Then(value => new WindowFrame(value.Item1, value.Item2.Start, value.Item2.End));
-        var baseWindowIdentifier = simpleIdentifier.When(
-            (_, identifier) => !identifier.Value.Equals("PARTITION", StringComparison.OrdinalIgnoreCase));
+        var baseWindowIdentifier = Not(PARTITION).SkipAnd(simpleIdentifier);
         var namedWindowSpecification = baseWindowIdentifier
             .And(windowPartitionBy.Optional())
             .And(windowOrderBy.Optional())
@@ -941,17 +940,21 @@ public static class SqlParser
                     value.Item1.Value.IsRecursive)
                 : value.Item2);
 
-        var parsedReturning = RETURNING.SkipAnd(Separated(comma, expression))
-            .And(INTO.SkipAnd(Separated(comma, expression)).Optional())
-            .Then(value => new ParsedReturning(
-                value.Item1,
-                value.Item2.HasValue ? value.Item2.Value : null));
-        Parser<ParsedReturning?> returning = syntax.SupportsReturning
-            ? parsedReturning
-                .When((_, value) => value.Into is null || syntax.SupportsReturningInto)
+        Parser<ParsedReturning?> returning = Always<ParsedReturning?>(null);
+        if (syntax.SupportsReturning)
+        {
+            var returningExpressions = RETURNING.SkipAnd(Separated(comma, expression));
+            var parsedReturning = syntax.SupportsReturningInto
+                ? returningExpressions
+                    .And(INTO.SkipAnd(Separated(comma, expression)).Optional())
+                    .Then(value => new ParsedReturning(
+                        value.Item1,
+                        value.Item2.HasValue ? value.Item2.Value : null))
+                : returningExpressions.Then(value => new ParsedReturning(value, null));
+            returning = parsedReturning
                 .Then<ParsedReturning?>(value => value)
-                .Or(Always<ParsedReturning?>(null))
-            : Always<ParsedReturning?>(null);
+                .Or(Always<ParsedReturning?>(null));
+        }
         var grant = GRANT.SkipAnd(Separated(comma, simpleIdentifier))
             .AndSkip(TO)
             .And(Separated(comma, simpleIdentifier))
@@ -985,20 +988,21 @@ public static class SqlParser
                 [value.Item2]));
         var insertColumns = Between(leftParenthesis, Separated(comma, simpleIdentifier), rightParenthesis);
         var insertValues = VALUES.SkipAnd(Separated(comma, valueRow));
+        var insertSource = insertValues
+            .Then(value => new ParsedInsertSource(value, null))
+            .Or(query.Then(value => new ParsedInsertSource(null, value)));
         var insert = INSERT.SkipAnd(INTO)
             .SkipAnd(tableName)
             .And(insertColumns.Optional())
-            .And(insertValues.Optional())
-            .And(query.Optional())
+            .And(insertSource)
             .And(returning)
-            .When((_, value) => value.Item3.HasValue || value.Item4.HasValue)
             .Then<SqlStatement>(value => new InsertStatement(
                 value.Item1,
                 value.Item2.HasValue ? value.Item2.Value : null,
-                value.Item3.HasValue ? value.Item3.Value : null,
-                value.Item4.HasValue ? value.Item4.Value : null,
-                value.Item5?.Expressions,
-                value.Item5?.Into));
+                value.Item3.Values,
+                value.Item3.Query,
+                value.Item4?.Expressions,
+                value.Item4?.Into));
 
         var assignment = column.AndSkip(Terms.Char('=')).And(expression)
             .Then(value => new Assignment((ColumnExpression)value.Item1, value.Item2));
@@ -2629,6 +2633,10 @@ public static class SqlParser
     private sealed record ParsedReturning(
         IReadOnlyList<SqlExpression> Expressions,
         IReadOnlyList<SqlExpression>? Into);
+
+    private readonly record struct ParsedInsertSource(
+        IReadOnlyList<IReadOnlyList<SqlExpression>>? Values,
+        SqlQuery? Query);
 
     private enum ParsedColumnModifierKind
     {

--- a/tests/Cyqwel.Tests/ParserTests.cs
+++ b/tests/Cyqwel.Tests/ParserTests.cs
@@ -325,6 +325,22 @@ public class ParserTests
     }
 
     [Fact]
+    public void Quoted_partition_is_valid_as_a_base_window_name()
+    {
+        var document = SqlDialects.PostgreSql.Parse(
+            """SELECT SUM(amount) OVER ("partition" ORDER BY created_at) FROM ledger""");
+
+        Assert.Single(document.Statements);
+    }
+
+    [Fact]
+    public void Insert_requires_exactly_one_source()
+    {
+        Assert.Throws<SqlParseException>(() =>
+            SqlParser.Parse("INSERT INTO archive VALUES (1) SELECT id FROM users"));
+    }
+
+    [Fact]
     public void Requires_semicolons_between_statements()
     {
         Assert.Throws<SqlParseException>(() => SqlParser.Parse("SELECT 1 SELECT 2"));


### PR DESCRIPTION
Semantic `When` predicates force the parser to build intermediate values before rejecting them and can add avoidable backtracking. This replaces eligible predicates with structural grammar choices so invalid branches are rejected earlier.

- Reject `PARTITION` as an unquoted base window name before allocating an identifier.
- Build dialect-specific `RETURNING` and `RETURNING INTO` parser graphs.
- Require `INSERT` to parse exactly one source: `VALUES` or a query.
- Cover quoted base window names and reject mixed `INSERT` sources.

Benchmarks on .NET 8 (median of 9 rounds):

| Scenario | Before | After | Change |
|---|---:|---:|---:|
| Anonymous window | 7,869.0 ns | 7,667.1 ns | 2.6% faster |
| Insert values returning | 7,913.0 ns | 7,577.5 ns | 4.2% faster |
| Insert select returning | 7,469.4 ns | 7,247.3 ns | 3.0% faster |
| Mixed batch | 19,172.9 ns | 18,437.2 ns | 3.8% faster |

Anonymous-window and mixed-batch parsing also allocate 80 fewer bytes per operation.