### PR TITLE
Add dialect-neutral current timestamp handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,36 @@ advanced joins, `EXPLAIN`, `MERGE`, `UPDATE FROM`, `DELETE USING`,
 Builder helpers only expose forms that can be parsed by at least one built-in
 dialect, so generated builder SQL can round-trip through the syntax tree.
 
+### Current timestamps
+
+Use `Sql.CurrentTimestamp()` for a dialect-neutral current timestamp:
+
+```csharp
+var query = Sql.SelectItems(new SelectItem(Sql.CurrentTimestamp())).Build();
+
+query.ToSql(SqlDialects.TSql);       // SELECT GETDATE()
+query.ToSql(SqlDialects.PostgreSql); // SELECT CURRENT_TIMESTAMP
+query.ToSql(SqlDialects.Oracle);     // SELECT CURRENT_TIMESTAMP
+```
+
+Generic SQL, MySQL, and SQLite also generate bare `CURRENT_TIMESTAMP`. Parsing
+normalizes bare `CURRENT_TIMESTAMP`, T-SQL `GETDATE()`, PostgreSQL/MySQL `NOW()`,
+and Oracle `SYSDATE` into `CurrentTimestampExpression`. The generic parser accepts
+all these forms. Empty-parenthesis `CURRENT_TIMESTAMP()` is also normalized for
+MySQL and generic SQL.
+
+Oracle `SYSDATE` retains `IsSystemDate = true` and renders back to `SYSDATE` for
+Oracle; other targets use their ordinary current timestamp. This abstraction
+does not guarantee identical clock, timezone, precision, or return-type semantics
+across databases. Oracle queries without `FROM` target Oracle 23+; generation
+does not insert `FROM DUAL`.
+
+Only unquoted, unqualified, no-argument forms without aggregate or window modifiers
+are normalized. Precision-bearing calls remain ordinary function expressions and
+retain their arguments; unsupported timestamp argument forms throw during
+generation unless `UnsupportedBehavior` is `Ignore`. UTC, local-time, date-only,
+and wall-clock functions are not included in this normalization.
+
 ## Stored procedures
 
 Stored procedures can be parsed, inspected, transformed, validated, and generated for T-SQL, PostgreSQL, MySQL,

--- a/README.md
+++ b/README.md
@@ -225,17 +225,43 @@ and Oracle `SYSDATE` into `CurrentTimestampExpression`. The generic parser accep
 all these forms. Empty-parenthesis `CURRENT_TIMESTAMP()` is also normalized for
 MySQL and generic SQL.
 
-Oracle `SYSDATE` retains `IsSystemDate = true` and renders back to `SYSDATE` for
-Oracle; other targets use their ordinary current timestamp. This abstraction
-does not guarantee identical clock, timezone, precision, or return-type semantics
-across databases. Oracle queries without `FROM` target Oracle 23+; generation
-does not insert `FROM DUAL`.
+`CurrentTimestampKind` selects `Default`, `SystemDate`, or `Utc`.
+Oracle `SYSDATE` parses with `Kind = CurrentTimestampKind.SystemDate` and renders
+back to `SYSDATE` for Oracle; other targets use their ordinary current timestamp.
+The default kind and the no-argument builder keep the behavior shown above.
 
-Only unquoted, unqualified, no-argument forms without aggregate or window modifiers
-are normalized. Precision-bearing calls remain ordinary function expressions and
-retain their arguments; unsupported timestamp argument forms throw during
-generation unless `UnsupportedBehavior` is `Ignore`. UTC, local-time, date-only,
-and wall-clock functions are not included in this normalization.
+Request UTC explicitly with `Sql.CurrentTimestamp(CurrentTimestampKind.Utc)`:
+
+| Target dialect | UTC expression |
+|---|---|
+| Generic, MySQL | `UTC_TIMESTAMP()` |
+| T-SQL | `GETUTCDATE()` |
+| PostgreSQL | `TIMEZONE('UTC', CURRENT_TIMESTAMP)` |
+| Oracle | `SYS_EXTRACT_UTC(CURRENT_TIMESTAMP)` |
+| SQLite | `DATETIME('now')` |
+
+UTC mode returns UTC date/time fields without a timezone offset, not a
+session-local display of a timezone-aware value. PostgreSQL and Oracle return
+timestamps without timezone metadata; SQLite returns text. Native SQL types,
+precision, and transaction/statement/wall-clock timing still vary by database.
+No session timezone is changed. SQLite's default `CURRENT_TIMESTAMP` is already
+UTC; `DATETIME('now')` lets the explicit UTC kind round-trip through the parser.
+
+The UTC expressions above parse back into the UTC kind in their respective
+dialects. MySQL also accepts bare `UTC_TIMESTAMP`, PostgreSQL recognizes
+`TIMEZONE('UTC', NOW())`, and Oracle recognizes `SYS_EXTRACT_UTC(SYSTIMESTAMP)`.
+The generic parser accepts all these spellings.
+
+Only unquoted, unqualified built-ins without aggregate or window modifiers are
+normalized. UTC wrappers are recognized only for the specific current-time
+arguments above, not arbitrary timestamps or timezones. Precision-bearing calls
+remain ordinary function expressions and retain their arguments; unsupported
+timestamp argument forms throw during generation unless `UnsupportedBehavior`
+is `Ignore`. Higher-precision variants such as `SYSUTCDATETIME()`, local-time,
+date-only, and separate wall-clock functions are outside this normalization.
+
+Oracle queries without `FROM` target Oracle 23+; generation does not insert
+`FROM DUAL`.
 
 ## Stored procedures
 

--- a/src/Cyqwel/Ast/Expressions.cs
+++ b/src/Cyqwel/Ast/Expressions.cs
@@ -28,11 +28,19 @@ public sealed record StarExpression(IReadOnlyList<SqlIdentifier>? Qualifier = nu
 
 public sealed record LiteralExpression(object? Value) : SqlExpression;
 
+public enum CurrentTimestampKind
+{
+    Default,
+    SystemDate,
+    Utc,
+}
+
 /// <summary>
-/// The target dialect's current timestamp. IsSystemDate preserves Oracle SYSDATE semantics
-/// when generating Oracle SQL; other targets use their ordinary current timestamp.
+/// The target dialect's current timestamp. SystemDate preserves Oracle SYSDATE on Oracle.
+/// Utc returns UTC date/time fields without a timezone offset; native types and clock precision vary by dialect.
 /// </summary>
-public sealed record CurrentTimestampExpression(bool IsSystemDate = false) : SqlExpression;
+public sealed record CurrentTimestampExpression(
+    CurrentTimestampKind Kind = CurrentTimestampKind.Default) : SqlExpression;
 
 public enum TrimDirection
 {

--- a/src/Cyqwel/Ast/Expressions.cs
+++ b/src/Cyqwel/Ast/Expressions.cs
@@ -28,6 +28,12 @@ public sealed record StarExpression(IReadOnlyList<SqlIdentifier>? Qualifier = nu
 
 public sealed record LiteralExpression(object? Value) : SqlExpression;
 
+/// <summary>
+/// The target dialect's current timestamp. IsSystemDate preserves Oracle SYSDATE semantics
+/// when generating Oracle SQL; other targets use their ordinary current timestamp.
+/// </summary>
+public sealed record CurrentTimestampExpression(bool IsSystemDate = false) : SqlExpression;
+
 public enum TrimDirection
 {
     Leading,

--- a/src/Cyqwel/Builders/Sql.cs
+++ b/src/Cyqwel/Builders/Sql.cs
@@ -46,7 +46,16 @@ public static class Sql
 
     public static ParameterExpression Param(string name, char prefix = '@') => new(name, prefix);
 
-    public static CurrentTimestampExpression CurrentTimestamp() => new();
+    public static CurrentTimestampExpression CurrentTimestamp(
+        CurrentTimestampKind kind = CurrentTimestampKind.Default)
+    {
+        if (!Enum.IsDefined(kind))
+        {
+            throw new ArgumentOutOfRangeException(nameof(kind), kind, null);
+        }
+
+        return new(kind);
+    }
 
     public static SqlDocument Document(params SqlStatement[] statements)
     {

--- a/src/Cyqwel/Builders/Sql.cs
+++ b/src/Cyqwel/Builders/Sql.cs
@@ -46,6 +46,8 @@ public static class Sql
 
     public static ParameterExpression Param(string name, char prefix = '@') => new(name, prefix);
 
+    public static CurrentTimestampExpression CurrentTimestamp() => new();
+
     public static SqlDocument Document(params SqlStatement[] statements)
     {
         ArgumentNullException.ThrowIfNull(statements);

--- a/src/Cyqwel/Dialects/SqlDialect.cs
+++ b/src/Cyqwel/Dialects/SqlDialect.cs
@@ -127,19 +127,33 @@ public class SqlDialect
         FunctionCallExpression function,
         Func<SqlExpression, string> renderExpression,
         SqlGenerationOptions options) =>
-        function.Name.Value.Equals("CURRENT_TIMESTAMP", StringComparison.OrdinalIgnoreCase)
-            ? RenderCurrentTimestampFunction(function, options, supportsArguments: true)
-            : null;
+        function.Name.Value.ToUpperInvariant() switch
+        {
+            "CURRENT_TIMESTAMP" => RenderCurrentTimestampFunction(function, options, supportsArguments: true),
+            "UTC_TIMESTAMP" => RenderCurrentTimestampFunction(
+                function, options, supportsArguments: true, kind: CurrentTimestampKind.Utc),
+            _ => null,
+        };
 
     public virtual string RenderCurrentTimestamp(
         CurrentTimestampExpression timestamp,
         SqlGenerationOptions options) =>
-        options.UppercaseKeywords ? "CURRENT_TIMESTAMP" : "current_timestamp";
+        timestamp.Kind switch
+        {
+            CurrentTimestampKind.Default or CurrentTimestampKind.SystemDate =>
+                options.UppercaseKeywords ? "CURRENT_TIMESTAMP" : "current_timestamp",
+            CurrentTimestampKind.Utc => $"{FormatTimestampFunctionName("UTC_TIMESTAMP", options)}()",
+            _ => throw new ArgumentOutOfRangeException(nameof(timestamp), timestamp.Kind, "Unknown current timestamp kind."),
+        };
+
+    protected static string FormatTimestampFunctionName(string name, SqlGenerationOptions options) =>
+        options.FunctionNameCase == FunctionNameCase.Lower ? name.ToLowerInvariant() : name;
 
     protected string? RenderCurrentTimestampFunction(
         FunctionCallExpression function,
         SqlGenerationOptions options,
-        bool supportsArguments = false)
+        bool supportsArguments = false,
+        CurrentTimestampKind kind = CurrentTimestampKind.Default)
     {
         if (function.Name.IsQuoted
             || function.IsDistinct
@@ -160,7 +174,7 @@ public class SqlDialect
             return null;
         }
 
-        return RenderCurrentTimestamp(new CurrentTimestampExpression(), options);
+        return RenderCurrentTimestamp(new CurrentTimestampExpression(kind), options);
     }
 
     public virtual string? RenderParameter(ParameterExpression parameter) => null;
@@ -264,7 +278,7 @@ public static class SqlDialects
             SupportsNullOrdering = false,
             SupportsStoredProcedures = true,
             SupportsAnonymousProceduralBlocks = true,
-            CurrentTimestampSyntax = SqlCurrentTimestampSyntax.GetDate,
+            CurrentTimestampSyntax = SqlCurrentTimestampSyntax.GetDate | SqlCurrentTimestampSyntax.GetUtcDate,
             DoublePipeBehavior = SqlDoublePipeBehavior.Concatenate,
         };
         public override string TrueLiteral => "1";
@@ -282,15 +296,25 @@ public static class SqlDialects
         public override string RenderCurrentTimestamp(
             CurrentTimestampExpression timestamp,
             SqlGenerationOptions options) =>
-            options.FunctionNameCase == FunctionNameCase.Lower ? "getdate()" : "GETDATE()";
+            timestamp.Kind switch
+            {
+                CurrentTimestampKind.Default or CurrentTimestampKind.SystemDate =>
+                    $"{FormatTimestampFunctionName("GETDATE", options)}()",
+                CurrentTimestampKind.Utc => $"{FormatTimestampFunctionName("GETUTCDATE", options)}()",
+                _ => base.RenderCurrentTimestamp(timestamp, options),
+            };
 
         public override string? RenderFunction(
             FunctionCallExpression function,
             Func<SqlExpression, string> renderExpression,
             SqlGenerationOptions options) =>
-            function.Name.Value.ToUpperInvariant() is "NOW" or "CURRENT_TIMESTAMP" or "GETDATE"
-                ? RenderCurrentTimestampFunction(function, options)
-                : base.RenderFunction(function, renderExpression, options);
+            function.Name.Value.ToUpperInvariant() switch
+            {
+                "NOW" or "CURRENT_TIMESTAMP" or "GETDATE" => RenderCurrentTimestampFunction(function, options),
+                "GETUTCDATE" or "UTC_TIMESTAMP" =>
+                    RenderCurrentTimestampFunction(function, options, kind: CurrentTimestampKind.Utc),
+                _ => base.RenderFunction(function, renderExpression, options),
+            };
 
     }
 
@@ -314,6 +338,7 @@ public static class SqlDialects
             SupportsILike = false,
             SupportsNullOrdering = true,
             SupportsStoredProcedures = false,
+            CurrentTimestampSyntax = SqlCurrentTimestampSyntax.DateTimeUtc,
             DoublePipeBehavior = SqlDoublePipeBehavior.Concatenate,
         };
         public override string TrueLiteral => "1";
@@ -334,9 +359,19 @@ public static class SqlDialects
             FunctionCallExpression function,
             Func<SqlExpression, string> renderExpression,
             SqlGenerationOptions options) =>
-            function.Name.Value.ToUpperInvariant() is "NOW" or "CURRENT_TIMESTAMP"
-                ? RenderCurrentTimestampFunction(function, options)
-                : base.RenderFunction(function, renderExpression, options);
+            function.Name.Value.ToUpperInvariant() switch
+            {
+                "NOW" or "CURRENT_TIMESTAMP" => RenderCurrentTimestampFunction(function, options),
+                "UTC_TIMESTAMP" => RenderCurrentTimestampFunction(function, options, kind: CurrentTimestampKind.Utc),
+                _ => base.RenderFunction(function, renderExpression, options),
+            };
+
+        public override string RenderCurrentTimestamp(
+            CurrentTimestampExpression timestamp,
+            SqlGenerationOptions options) =>
+            timestamp.Kind == CurrentTimestampKind.Utc
+                ? $"{FormatTimestampFunctionName("DATETIME", options)}('now')"
+                : base.RenderCurrentTimestamp(timestamp, options);
 
         public override SqlNode TransformNode(SqlNode node) => node switch
         {
@@ -427,7 +462,7 @@ public static class SqlDialects
             SupportsExplainOptions = true,
             SupportsStoredProcedures = true,
             SupportsAnonymousProceduralBlocks = true,
-            CurrentTimestampSyntax = SqlCurrentTimestampSyntax.Now,
+            CurrentTimestampSyntax = SqlCurrentTimestampSyntax.Now | SqlCurrentTimestampSyntax.TimezoneUtc,
             DoublePipeBehavior = SqlDoublePipeBehavior.Concatenate,
         };
 
@@ -435,10 +470,19 @@ public static class SqlDialects
             FunctionCallExpression function,
             Func<SqlExpression, string> renderExpression,
             SqlGenerationOptions options) =>
-            function.Name.Value.Equals("NOW", StringComparison.OrdinalIgnoreCase)
-                && function.Arguments.Count > 0
-                ? RenderCurrentTimestampFunction(function, options)
-                : base.RenderFunction(function, renderExpression, options);
+            function.Name.Value.ToUpperInvariant() switch
+            {
+                "NOW" when function.Arguments.Count > 0 => RenderCurrentTimestampFunction(function, options),
+                "UTC_TIMESTAMP" => RenderCurrentTimestampFunction(function, options, kind: CurrentTimestampKind.Utc),
+                _ => base.RenderFunction(function, renderExpression, options),
+            };
+
+        public override string RenderCurrentTimestamp(
+            CurrentTimestampExpression timestamp,
+            SqlGenerationOptions options) =>
+            timestamp.Kind == CurrentTimestampKind.Utc
+                ? $"{FormatTimestampFunctionName("TIMEZONE", options)}('UTC', {base.RenderCurrentTimestamp(new(), options)})"
+                : base.RenderCurrentTimestamp(timestamp, options);
     }
 
     private sealed class MySqlDialect() : SqlDialect("mysql", '`', '`', SqlLimitStyle.LimitOffsetComma)
@@ -465,7 +509,8 @@ public static class SqlDialects
             SupportsCreateViewSecurity = true,
             SupportsStoredProcedures = true,
             CurrentTimestampSyntax = SqlCurrentTimestampSyntax.Now
-                | SqlCurrentTimestampSyntax.CurrentTimestampFunction,
+                | SqlCurrentTimestampSyntax.CurrentTimestampFunction
+                | SqlCurrentTimestampSyntax.UtcTimestamp,
             DoublePipeBehavior = SqlDoublePipeBehavior.LogicalOr,
         };
 
@@ -499,7 +544,7 @@ public static class SqlDialects
             SupportsOracleDataTypes = true,
             SupportsStoredProcedures = true,
             SupportsAnonymousProceduralBlocks = true,
-            CurrentTimestampSyntax = SqlCurrentTimestampSyntax.SysDate,
+            CurrentTimestampSyntax = SqlCurrentTimestampSyntax.SysDate | SqlCurrentTimestampSyntax.SysExtractUtc,
             DoublePipeBehavior = SqlDoublePipeBehavior.Concatenate,
         };
 
@@ -520,9 +565,13 @@ public static class SqlDialects
         public override string RenderCurrentTimestamp(
             CurrentTimestampExpression timestamp,
             SqlGenerationOptions options) =>
-            timestamp.IsSystemDate
-                ? options.UppercaseKeywords ? "SYSDATE" : "sysdate"
-                : base.RenderCurrentTimestamp(timestamp, options);
+            timestamp.Kind switch
+            {
+                CurrentTimestampKind.SystemDate => options.UppercaseKeywords ? "SYSDATE" : "sysdate",
+                CurrentTimestampKind.Utc =>
+                    $"{FormatTimestampFunctionName("SYS_EXTRACT_UTC", options)}({base.RenderCurrentTimestamp(new(), options)})",
+                _ => base.RenderCurrentTimestamp(timestamp, options),
+            };
 
         public override string? RenderFunction(
             FunctionCallExpression function,
@@ -532,6 +581,11 @@ public static class SqlDialects
             if (function.Name.Value.Equals("NOW", StringComparison.OrdinalIgnoreCase))
             {
                 return RenderCurrentTimestampFunction(function, options);
+            }
+
+            if (function.Name.Value.Equals("UTC_TIMESTAMP", StringComparison.OrdinalIgnoreCase))
+            {
+                return RenderCurrentTimestampFunction(function, options, kind: CurrentTimestampKind.Utc);
             }
 
             if (function.Name.Value.Equals("COALESCE", StringComparison.OrdinalIgnoreCase)

--- a/src/Cyqwel/Dialects/SqlDialect.cs
+++ b/src/Cyqwel/Dialects/SqlDialect.cs
@@ -126,7 +126,42 @@ public class SqlDialect
     public virtual string? RenderFunction(
         FunctionCallExpression function,
         Func<SqlExpression, string> renderExpression,
-        SqlGenerationOptions options) => null;
+        SqlGenerationOptions options) =>
+        function.Name.Value.Equals("CURRENT_TIMESTAMP", StringComparison.OrdinalIgnoreCase)
+            ? RenderCurrentTimestampFunction(function, options, supportsArguments: true)
+            : null;
+
+    public virtual string RenderCurrentTimestamp(
+        CurrentTimestampExpression timestamp,
+        SqlGenerationOptions options) =>
+        options.UppercaseKeywords ? "CURRENT_TIMESTAMP" : "current_timestamp";
+
+    protected string? RenderCurrentTimestampFunction(
+        FunctionCallExpression function,
+        SqlGenerationOptions options,
+        bool supportsArguments = false)
+    {
+        if (function.Name.IsQuoted
+            || function.IsDistinct
+            || function.Filter is not null
+            || function.WithinGroup is { Count: > 0 })
+        {
+            return null;
+        }
+
+        if (function.Arguments.Count > 0)
+        {
+            if (!supportsArguments && options.UnsupportedBehavior == UnsupportedSqlBehavior.Throw)
+            {
+                throw new NotSupportedException(
+                    $"{Name} does not support arguments to {function.Name.Value}.");
+            }
+
+            return null;
+        }
+
+        return RenderCurrentTimestamp(new CurrentTimestampExpression(), options);
+    }
 
     public virtual string? RenderParameter(ParameterExpression parameter) => null;
 
@@ -229,6 +264,7 @@ public static class SqlDialects
             SupportsNullOrdering = false,
             SupportsStoredProcedures = true,
             SupportsAnonymousProceduralBlocks = true,
+            CurrentTimestampSyntax = SqlCurrentTimestampSyntax.GetDate,
             DoublePipeBehavior = SqlDoublePipeBehavior.Concatenate,
         };
         public override string TrueLiteral => "1";
@@ -236,13 +272,25 @@ public static class SqlDialects
 
         public override string GetFunctionName(string name) => name.ToUpperInvariant() switch
         {
-            "CURRENT_TIMESTAMP" or "NOW" => "GETDATE",
             "CLOCK_TIMESTAMP" => "SYSDATETIME",
             "LN" => "LOG",
             "CHR" => "CHAR",
             "REPEAT" => "REPLICATE",
             _ => name,
         };
+
+        public override string RenderCurrentTimestamp(
+            CurrentTimestampExpression timestamp,
+            SqlGenerationOptions options) =>
+            options.FunctionNameCase == FunctionNameCase.Lower ? "getdate()" : "GETDATE()";
+
+        public override string? RenderFunction(
+            FunctionCallExpression function,
+            Func<SqlExpression, string> renderExpression,
+            SqlGenerationOptions options) =>
+            function.Name.Value.ToUpperInvariant() is "NOW" or "CURRENT_TIMESTAMP" or "GETDATE"
+                ? RenderCurrentTimestampFunction(function, options)
+                : base.RenderFunction(function, renderExpression, options);
 
     }
 
@@ -273,7 +321,6 @@ public static class SqlDialects
 
         public override string GetFunctionName(string name) => name.ToUpperInvariant() switch
         {
-            "NOW" => "DATETIME",
             "LEAST" => "MIN",
             "GREATEST" => "MAX",
             "JSON_AGG" or "JSONB_AGG" => "JSON_GROUP_ARRAY",
@@ -282,6 +329,14 @@ public static class SqlDialects
             "JSON_BUILD_ARRAY" => "JSON_ARRAY",
             _ => name,
         };
+
+        public override string? RenderFunction(
+            FunctionCallExpression function,
+            Func<SqlExpression, string> renderExpression,
+            SqlGenerationOptions options) =>
+            function.Name.Value.ToUpperInvariant() is "NOW" or "CURRENT_TIMESTAMP"
+                ? RenderCurrentTimestampFunction(function, options)
+                : base.RenderFunction(function, renderExpression, options);
 
         public override SqlNode TransformNode(SqlNode node) => node switch
         {
@@ -372,8 +427,18 @@ public static class SqlDialects
             SupportsExplainOptions = true,
             SupportsStoredProcedures = true,
             SupportsAnonymousProceduralBlocks = true,
+            CurrentTimestampSyntax = SqlCurrentTimestampSyntax.Now,
             DoublePipeBehavior = SqlDoublePipeBehavior.Concatenate,
         };
+
+        public override string? RenderFunction(
+            FunctionCallExpression function,
+            Func<SqlExpression, string> renderExpression,
+            SqlGenerationOptions options) =>
+            function.Name.Value.Equals("NOW", StringComparison.OrdinalIgnoreCase)
+                && function.Arguments.Count > 0
+                ? RenderCurrentTimestampFunction(function, options)
+                : base.RenderFunction(function, renderExpression, options);
     }
 
     private sealed class MySqlDialect() : SqlDialect("mysql", '`', '`', SqlLimitStyle.LimitOffsetComma)
@@ -399,6 +464,8 @@ public static class SqlDialects
             SupportsNullOrdering = false,
             SupportsCreateViewSecurity = true,
             SupportsStoredProcedures = true,
+            CurrentTimestampSyntax = SqlCurrentTimestampSyntax.Now
+                | SqlCurrentTimestampSyntax.CurrentTimestampFunction,
             DoublePipeBehavior = SqlDoublePipeBehavior.LogicalOr,
         };
 
@@ -432,6 +499,7 @@ public static class SqlDialects
             SupportsOracleDataTypes = true,
             SupportsStoredProcedures = true,
             SupportsAnonymousProceduralBlocks = true,
+            CurrentTimestampSyntax = SqlCurrentTimestampSyntax.SysDate,
             DoublePipeBehavior = SqlDoublePipeBehavior.Concatenate,
         };
 
@@ -449,16 +517,21 @@ public static class SqlDialects
         public override string GetSetOperator(SetOperator value) =>
             value == SetOperator.Except ? "MINUS" : base.GetSetOperator(value);
 
+        public override string RenderCurrentTimestamp(
+            CurrentTimestampExpression timestamp,
+            SqlGenerationOptions options) =>
+            timestamp.IsSystemDate
+                ? options.UppercaseKeywords ? "SYSDATE" : "sysdate"
+                : base.RenderCurrentTimestamp(timestamp, options);
+
         public override string? RenderFunction(
             FunctionCallExpression function,
             Func<SqlExpression, string> renderExpression,
             SqlGenerationOptions options)
         {
-            if (function.Name.Value.Equals("NOW", StringComparison.OrdinalIgnoreCase)
-                || function.Name.Value.Equals("CURRENT_TIMESTAMP", StringComparison.OrdinalIgnoreCase)
-                    && function.Arguments.Count == 0)
+            if (function.Name.Value.Equals("NOW", StringComparison.OrdinalIgnoreCase))
             {
-                return "SYSTIMESTAMP";
+                return RenderCurrentTimestampFunction(function, options);
             }
 
             if (function.Name.Value.Equals("COALESCE", StringComparison.OrdinalIgnoreCase)
@@ -467,7 +540,7 @@ public static class SqlDialects
                 return $"NVL({renderExpression(function.Arguments[0])}, {renderExpression(function.Arguments[1])})";
             }
 
-            return null;
+            return base.RenderFunction(function, renderExpression, options);
         }
 
         public override string? RenderParameter(ParameterExpression parameter) =>
@@ -692,6 +765,11 @@ public sealed class SqlDialectBuilder
             SqlGenerationOptions options) =>
             functionRenderer?.Invoke(function, renderExpression, options)
             ?? baseDialect.RenderFunction(function, renderExpression, options);
+
+        public override string RenderCurrentTimestamp(
+            CurrentTimestampExpression timestamp,
+            SqlGenerationOptions options) =>
+            baseDialect.RenderCurrentTimestamp(timestamp, options);
 
         public override string? RenderParameter(ParameterExpression parameter) =>
             baseDialect.RenderParameter(parameter);

--- a/src/Cyqwel/Generation/SqlGenerator.cs
+++ b/src/Cyqwel/Generation/SqlGenerator.cs
@@ -729,7 +729,9 @@ public sealed partial class SqlGenerator
                 if (column.Parts.Count == 1
                     && (column.Parts[0].Value.Equals("CURRENT_TIMESTAMP", StringComparison.OrdinalIgnoreCase)
                         || _dialect.ParserOptions.CurrentTimestampSyntax.HasFlag(SqlCurrentTimestampSyntax.SysDate)
-                            && column.Parts[0].Value.Equals("SYSDATE", StringComparison.OrdinalIgnoreCase)))
+                            && column.Parts[0].Value.Equals("SYSDATE", StringComparison.OrdinalIgnoreCase)
+                        || _dialect.ParserOptions.CurrentTimestampSyntax.HasFlag(SqlCurrentTimestampSyntax.UtcTimestamp)
+                            && column.Parts[0].Value.Equals("UTC_TIMESTAMP", StringComparison.OrdinalIgnoreCase)))
                 {
                     WriteIdentifier(column.Parts[0] with { IsQuoted = true });
                 }

--- a/src/Cyqwel/Generation/SqlGenerator.cs
+++ b/src/Cyqwel/Generation/SqlGenerator.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Text;
 using Cyqwel.Ast;
 using Cyqwel.Dialects;
+using Cyqwel.Parsing;
 
 namespace Cyqwel.Generation;
 
@@ -725,7 +726,17 @@ public sealed partial class SqlGenerator
         switch (expression)
         {
             case ColumnExpression column:
-                WriteSeparated(column.Parts, WriteIdentifier, ".");
+                if (column.Parts.Count == 1
+                    && (column.Parts[0].Value.Equals("CURRENT_TIMESTAMP", StringComparison.OrdinalIgnoreCase)
+                        || _dialect.ParserOptions.CurrentTimestampSyntax.HasFlag(SqlCurrentTimestampSyntax.SysDate)
+                            && column.Parts[0].Value.Equals("SYSDATE", StringComparison.OrdinalIgnoreCase)))
+                {
+                    WriteIdentifier(column.Parts[0] with { IsQuoted = true });
+                }
+                else
+                {
+                    WriteSeparated(column.Parts, WriteIdentifier, ".");
+                }
                 break;
             case StarExpression star:
                 if (star.Qualifier is { Count: > 0 })
@@ -738,6 +749,9 @@ public sealed partial class SqlGenerator
                 break;
             case LiteralExpression literal:
                 WriteLiteral(literal);
+                break;
+            case CurrentTimestampExpression timestamp:
+                _builder.Append(_dialect.RenderCurrentTimestamp(timestamp, _options));
                 break;
             case TrimExpression trim:
                 WriteTrim(trim);
@@ -986,14 +1000,23 @@ public sealed partial class SqlGenerator
             return;
         }
 
-        var name = _dialect.GetFunctionName(function.Name.Value);
-        name = _options.FunctionNameCase switch
+        if (function.Name.IsQuoted)
         {
-            FunctionNameCase.Upper => name.ToUpperInvariant(),
-            FunctionNameCase.Lower => name.ToLowerInvariant(),
-            _ => name,
-        };
-        _builder.Append(name).Append('(');
+            WriteIdentifier(function.Name);
+        }
+        else
+        {
+            var name = _dialect.GetFunctionName(function.Name.Value);
+            name = _options.FunctionNameCase switch
+            {
+                FunctionNameCase.Upper => name.ToUpperInvariant(),
+                FunctionNameCase.Lower => name.ToLowerInvariant(),
+                _ => name,
+            };
+            _builder.Append(name);
+        }
+
+        _builder.Append('(');
         if (function.IsDistinct)
         {
             Keyword("DISTINCT");

--- a/src/Cyqwel/Parsing/SqlDialectParserOptions.cs
+++ b/src/Cyqwel/Parsing/SqlDialectParserOptions.cs
@@ -35,6 +35,11 @@ public enum SqlCurrentTimestampSyntax
     GetDate = 2,
     Now = 4,
     SysDate = 8,
+    UtcTimestamp = 16,
+    GetUtcDate = 32,
+    TimezoneUtc = 64,
+    SysExtractUtc = 128,
+    DateTimeUtc = 256,
 }
 
 // Parser implementation detail. Public callers select a dialect and capabilities,
@@ -87,7 +92,12 @@ public sealed record SqlDialectParserOptions
         CurrentTimestampSyntax = SqlCurrentTimestampSyntax.CurrentTimestampFunction
             | SqlCurrentTimestampSyntax.GetDate
             | SqlCurrentTimestampSyntax.Now
-            | SqlCurrentTimestampSyntax.SysDate,
+            | SqlCurrentTimestampSyntax.SysDate
+            | SqlCurrentTimestampSyntax.UtcTimestamp
+            | SqlCurrentTimestampSyntax.GetUtcDate
+            | SqlCurrentTimestampSyntax.TimezoneUtc
+            | SqlCurrentTimestampSyntax.SysExtractUtc
+            | SqlCurrentTimestampSyntax.DateTimeUtc,
         DoublePipeBehavior = SqlDoublePipeBehavior.Concatenate,
     };
 

--- a/src/Cyqwel/Parsing/SqlDialectParserOptions.cs
+++ b/src/Cyqwel/Parsing/SqlDialectParserOptions.cs
@@ -27,6 +27,16 @@ public enum SqlDoublePipeBehavior
     LogicalOr,
 }
 
+[Flags]
+public enum SqlCurrentTimestampSyntax
+{
+    None = 0,
+    CurrentTimestampFunction = 1,
+    GetDate = 2,
+    Now = 4,
+    SysDate = 8,
+}
+
 // Parser implementation detail. Public callers select a dialect and capabilities,
 // not a procedural vendor/style taxonomy.
 [Flags]
@@ -74,6 +84,10 @@ public sealed record SqlDialectParserOptions
         SupportsOracleDataTypes = true,
         SupportsStoredProcedures = true,
         SupportsAnonymousProceduralBlocks = true,
+        CurrentTimestampSyntax = SqlCurrentTimestampSyntax.CurrentTimestampFunction
+            | SqlCurrentTimestampSyntax.GetDate
+            | SqlCurrentTimestampSyntax.Now
+            | SqlCurrentTimestampSyntax.SysDate,
         DoublePipeBehavior = SqlDoublePipeBehavior.Concatenate,
     };
 
@@ -124,6 +138,11 @@ public sealed record SqlDialectParserOptions
     public bool SupportsStoredProcedures { get; init; }
 
     public bool SupportsAnonymousProceduralBlocks { get; init; }
+
+    /// <summary>
+    /// Additional current-timestamp spellings. Bare CURRENT_TIMESTAMP is always supported.
+    /// </summary>
+    public SqlCurrentTimestampSyntax CurrentTimestampSyntax { get; init; }
 
     public SqlDoublePipeBehavior DoublePipeBehavior { get; init; } = SqlDoublePipeBehavior.Concatenate;
 }

--- a/src/Cyqwel/Parsing/SqlParser.cs
+++ b/src/Cyqwel/Parsing/SqlParser.cs
@@ -249,6 +249,20 @@ public static class SqlParser
         var tableName = tableIdentifierParts.Then(parts => new TableName(parts));
         var column = identifierParts.Then<SqlExpression>(parts =>
         {
+            if (parts.Count == 1 && !parts[0].IsQuoted)
+            {
+                if (parts[0].Value.Equals("CURRENT_TIMESTAMP", StringComparison.OrdinalIgnoreCase))
+                {
+                    return new CurrentTimestampExpression { Span = parts[0].Span };
+                }
+
+                if (syntax.CurrentTimestampSyntax.HasFlag(SqlCurrentTimestampSyntax.SysDate)
+                    && parts[0].Value.Equals("SYSDATE", StringComparison.OrdinalIgnoreCase))
+                {
+                    return new CurrentTimestampExpression(IsSystemDate: true) { Span = parts[0].Span };
+                }
+            }
+
             if (parts.Count > 1
                 && parts[^1].Value.Equals("NEXTVAL", StringComparison.OrdinalIgnoreCase))
             {
@@ -332,6 +346,27 @@ public static class SqlParser
                     WithinGroup = value.Item2.HasValue ? value.Item2.Value : null,
                     Filter = value.Item3.HasValue ? value.Item3.Value : null,
                 };
+                if (!value.Item4.HasValue
+                    && !call.Name.IsQuoted
+                    && call.Arguments.Count == 0
+                    && !call.IsDistinct
+                    && call.WithinGroup is null
+                    && call.Filter is null)
+                {
+                    var timestampSyntax = call.Name.Value.ToUpperInvariant() switch
+                    {
+                        "CURRENT_TIMESTAMP" => SqlCurrentTimestampSyntax.CurrentTimestampFunction,
+                        "GETDATE" => SqlCurrentTimestampSyntax.GetDate,
+                        "NOW" => SqlCurrentTimestampSyntax.Now,
+                        _ => SqlCurrentTimestampSyntax.None,
+                    };
+                    if (timestampSyntax != SqlCurrentTimestampSyntax.None
+                        && syntax.CurrentTimestampSyntax.HasFlag(timestampSyntax))
+                    {
+                        return new CurrentTimestampExpression { Span = call.Span };
+                    }
+                }
+
                 return value.Item4.HasValue
                     ? new WindowExpression(
                         call,
@@ -1004,8 +1039,9 @@ public static class SqlParser
                 value.Item4?.Expressions,
                 value.Item4?.Into));
 
-        var assignment = column.AndSkip(Terms.Char('=')).And(expression)
-            .Then(value => new Assignment((ColumnExpression)value.Item1, value.Item2));
+        var assignment = identifierParts.Then(parts => new ColumnExpression(parts))
+            .AndSkip(Terms.Char('=')).And(expression)
+            .Then(value => new Assignment(value.Item1, value.Item2));
         var update = UPDATE.SkipAnd(namedTable)
             .AndSkip(SET)
             .And(Separated(comma, assignment))

--- a/src/Cyqwel/Parsing/SqlParser.cs
+++ b/src/Cyqwel/Parsing/SqlParser.cs
@@ -259,7 +259,13 @@ public static class SqlParser
                 if (syntax.CurrentTimestampSyntax.HasFlag(SqlCurrentTimestampSyntax.SysDate)
                     && parts[0].Value.Equals("SYSDATE", StringComparison.OrdinalIgnoreCase))
                 {
-                    return new CurrentTimestampExpression(IsSystemDate: true) { Span = parts[0].Span };
+                    return new CurrentTimestampExpression(CurrentTimestampKind.SystemDate) { Span = parts[0].Span };
+                }
+
+                if (syntax.CurrentTimestampSyntax.HasFlag(SqlCurrentTimestampSyntax.UtcTimestamp)
+                    && parts[0].Value.Equals("UTC_TIMESTAMP", StringComparison.OrdinalIgnoreCase))
+                {
+                    return new CurrentTimestampExpression(CurrentTimestampKind.Utc) { Span = parts[0].Span };
                 }
             }
 
@@ -346,27 +352,6 @@ public static class SqlParser
                     WithinGroup = value.Item2.HasValue ? value.Item2.Value : null,
                     Filter = value.Item3.HasValue ? value.Item3.Value : null,
                 };
-                if (!value.Item4.HasValue
-                    && !call.Name.IsQuoted
-                    && call.Arguments.Count == 0
-                    && !call.IsDistinct
-                    && call.WithinGroup is null
-                    && call.Filter is null)
-                {
-                    var timestampSyntax = call.Name.Value.ToUpperInvariant() switch
-                    {
-                        "CURRENT_TIMESTAMP" => SqlCurrentTimestampSyntax.CurrentTimestampFunction,
-                        "GETDATE" => SqlCurrentTimestampSyntax.GetDate,
-                        "NOW" => SqlCurrentTimestampSyntax.Now,
-                        _ => SqlCurrentTimestampSyntax.None,
-                    };
-                    if (timestampSyntax != SqlCurrentTimestampSyntax.None
-                        && syntax.CurrentTimestampSyntax.HasFlag(timestampSyntax))
-                    {
-                        return new CurrentTimestampExpression { Span = call.Span };
-                    }
-                }
-
                 return value.Item4.HasValue
                     ? new WindowExpression(
                         call,
@@ -374,7 +359,7 @@ public static class SqlParser
                         value.Item4.Value.OrderBy,
                         value.Item4.Value.Frame,
                         value.Item4.Value.WindowName)
-                    : call;
+                    : NormalizeCurrentTimestamp(call, syntax.CurrentTimestampSyntax);
             });
 
         var dataTypeArgument = Terms.Char('-').Optional()
@@ -2038,6 +2023,51 @@ public static class SqlParser
     }
 
     private static Parser<string> Keyword(string value) => Terms.Keyword(value, caseInsensitive: true);
+
+    private static SqlExpression NormalizeCurrentTimestamp(
+        FunctionCallExpression function,
+        SqlCurrentTimestampSyntax syntax)
+    {
+        if (function.Name.IsQuoted
+            || function.IsDistinct
+            || function.Filter is not null
+            || function.WithinGroup is not null)
+        {
+            return function;
+        }
+
+        var (requiredSyntax, kind) = function.Name.Value.ToUpperInvariant() switch
+        {
+            "CURRENT_TIMESTAMP" when function.Arguments.Count == 0 =>
+                (SqlCurrentTimestampSyntax.CurrentTimestampFunction, CurrentTimestampKind.Default),
+            "GETDATE" when function.Arguments.Count == 0 =>
+                (SqlCurrentTimestampSyntax.GetDate, CurrentTimestampKind.Default),
+            "NOW" when function.Arguments.Count == 0 =>
+                (SqlCurrentTimestampSyntax.Now, CurrentTimestampKind.Default),
+            "UTC_TIMESTAMP" when function.Arguments.Count == 0 =>
+                (SqlCurrentTimestampSyntax.UtcTimestamp, CurrentTimestampKind.Utc),
+            "GETUTCDATE" when function.Arguments.Count == 0 =>
+                (SqlCurrentTimestampSyntax.GetUtcDate, CurrentTimestampKind.Utc),
+            "TIMEZONE" when function.Arguments is
+                [LiteralExpression { Value: string zone }, CurrentTimestampExpression { Kind: CurrentTimestampKind.Default }]
+                && zone.Equals("UTC", StringComparison.OrdinalIgnoreCase) =>
+                (SqlCurrentTimestampSyntax.TimezoneUtc, CurrentTimestampKind.Utc),
+            "SYS_EXTRACT_UTC" when function.Arguments is
+                [CurrentTimestampExpression { Kind: CurrentTimestampKind.Default }] =>
+                (SqlCurrentTimestampSyntax.SysExtractUtc, CurrentTimestampKind.Utc),
+            "SYS_EXTRACT_UTC" when function.Arguments is
+                [ColumnExpression { Parts: [{ IsQuoted: false, Value: var name }] }]
+                && name.Equals("SYSTIMESTAMP", StringComparison.OrdinalIgnoreCase) =>
+                (SqlCurrentTimestampSyntax.SysExtractUtc, CurrentTimestampKind.Utc),
+            "DATETIME" when function.Arguments is [LiteralExpression { Value: "now" }] =>
+                (SqlCurrentTimestampSyntax.DateTimeUtc, CurrentTimestampKind.Utc),
+            _ => (SqlCurrentTimestampSyntax.None, CurrentTimestampKind.Default),
+        };
+
+        return requiredSyntax != SqlCurrentTimestampSyntax.None && syntax.HasFlag(requiredSyntax)
+            ? new CurrentTimestampExpression(kind) { Span = function.Span }
+            : function;
+    }
 
     private static bool LooksLikeStoredProcedure(string sql)
     {

--- a/src/Cyqwel/Validation/SchemaValidationEngine.cs
+++ b/src/Cyqwel/Validation/SchemaValidationEngine.cs
@@ -502,6 +502,8 @@ internal sealed class SchemaValidationEngine
                 return SqlTypeFamily.Unknown;
             case LiteralExpression literal:
                 return LiteralType(literal.Value);
+            case CurrentTimestampExpression:
+                return SqlTypeFamily.Timestamp;
             case ParameterExpression parameter:
                 if (parameter.DefaultValue is not null)
                 {

--- a/src/Cyqwel/Visitors/SqlNodeChildren.cs
+++ b/src/Cyqwel/Visitors/SqlNodeChildren.cs
@@ -196,6 +196,7 @@ internal static partial class SqlNodeChildren
                 return SequenceOptionChildren(value);
             case SqlIdentifier:
             case LiteralExpression:
+            case CurrentTimestampExpression:
             case DefaultExpression:
             case MergeDeleteAction:
                 return Array.Empty<SqlNode>();

--- a/src/Cyqwel/Visitors/SqlRewriter.cs
+++ b/src/Cyqwel/Visitors/SqlRewriter.cs
@@ -45,6 +45,7 @@ public abstract partial class SqlRewriter
             ColumnExpression value => VisitColumn(value),
             StarExpression value => VisitStar(value),
             LiteralExpression value => VisitLiteral(value),
+            CurrentTimestampExpression value => VisitCurrentTimestamp(value),
             TrimExpression value => VisitTrim(value),
             TypedLiteralExpression value => VisitTypedLiteral(value),
             HexLiteralExpression value => VisitHexLiteral(value),
@@ -113,6 +114,8 @@ public abstract partial class SqlRewriter
     }
 
     public T Visit<T>(T node) where T : SqlNode => (T)Visit((SqlNode)node);
+
+    protected virtual SqlNode VisitCurrentTimestamp(CurrentTimestampExpression node) => node;
 
     protected virtual SqlNode VisitDocument(SqlDocument node) =>
         Update(node, VisitList(node.Statements), node.Statements, static (n, statements) => n with { Statements = statements });

--- a/src/Cyqwel/Visitors/SqlVisitor.cs
+++ b/src/Cyqwel/Visitors/SqlVisitor.cs
@@ -45,6 +45,7 @@ public abstract partial class SqlVisitor
             case ColumnExpression value: VisitColumn(value); break;
             case StarExpression value: VisitStar(value); break;
             case LiteralExpression value: VisitLiteral(value); break;
+            case CurrentTimestampExpression value: VisitCurrentTimestamp(value); break;
             case TrimExpression value: VisitTrim(value); break;
             case TypedLiteralExpression value: VisitTypedLiteral(value); break;
             case HexLiteralExpression value: VisitHexLiteral(value); break;
@@ -133,6 +134,7 @@ public abstract partial class SqlVisitor
     protected virtual void VisitColumn(ColumnExpression node) => DefaultVisit(node);
     protected virtual void VisitStar(StarExpression node) => DefaultVisit(node);
     protected virtual void VisitLiteral(LiteralExpression node) => DefaultVisit(node);
+    protected virtual void VisitCurrentTimestamp(CurrentTimestampExpression node) => DefaultVisit(node);
     protected virtual void VisitTrim(TrimExpression node) => DefaultVisit(node);
     protected virtual void VisitTypedLiteral(TypedLiteralExpression node) => DefaultVisit(node);
     protected virtual void VisitHexLiteral(HexLiteralExpression node) => DefaultVisit(node);

--- a/tests/Cyqwel.Tests/CurrentTimestampTests.cs
+++ b/tests/Cyqwel.Tests/CurrentTimestampTests.cs
@@ -30,7 +30,7 @@ public class CurrentTimestampTests
         var expression = ParseExpression(SqlDialectRegistry.Get(dialectName), sql);
 
         var timestamp = Assert.IsType<CurrentTimestampExpression>(expression);
-        Assert.Equal(systemDate, timestamp.IsSystemDate);
+        Assert.Equal(systemDate ? CurrentTimestampKind.SystemDate : CurrentTimestampKind.Default, timestamp.Kind);
         if (!systemDate)
         {
             Assert.Equal(Sql.CurrentTimestamp(), timestamp);
@@ -71,8 +71,9 @@ public class CurrentTimestampTests
         const string sql = "SELECT SYSDATE, CURRENT_TIMESTAMP, TRUNC(SYSDATE)";
         var document = SqlDialects.Oracle.Parse(sql);
 
-        Assert.Equal([true, false, true],
-            document.FindAll<CurrentTimestampExpression>().Select(timestamp => timestamp.IsSystemDate));
+        Assert.Equal(
+            [CurrentTimestampKind.SystemDate, CurrentTimestampKind.Default, CurrentTimestampKind.SystemDate],
+            document.FindAll<CurrentTimestampExpression>().Select(timestamp => timestamp.Kind));
         Assert.Equal(sql, document.ToSql(SqlDialects.Oracle));
         Assert.Equal(
             "SELECT CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, TRUNC(CURRENT_TIMESTAMP)",
@@ -83,8 +84,8 @@ public class CurrentTimestampTests
         Assert.Equal(
             "SELECT CURRENT_TIMESTAMP",
             Sql.Select(Sql.CurrentTimestamp()).ToSql(SqlDialects.Oracle));
-        Assert.True(Assert.IsType<CurrentTimestampExpression>(
-            ParseExpression(SqlDialects.Oracle, "SYSDATE")).IsSystemDate);
+        Assert.Equal(CurrentTimestampKind.SystemDate, Assert.IsType<CurrentTimestampExpression>(
+            ParseExpression(SqlDialects.Oracle, "SYSDATE")).Kind);
     }
 
     [Theory]
@@ -254,7 +255,7 @@ public class CurrentTimestampTests
     }
 
     [Theory]
-    [InlineData("tsql", "GETUTCDATE()")]
+    [InlineData("tsql", "SYSUTCDATETIME()")]
     [InlineData("tsql", "SYSDATETIME()")]
     [InlineData("tsql", "SYSDATETIMEOFFSET()")]
     [InlineData("postgresql", "CLOCK_TIMESTAMP()")]
@@ -340,7 +341,7 @@ public class CurrentTimestampTests
 
         Assert.Equal("current_timestamp", Sql.CurrentTimestamp().ToSql(SqlDialects.PostgreSql, options));
         Assert.Equal("getdate()", Sql.CurrentTimestamp().ToSql(SqlDialects.TSql, options));
-        Assert.Equal("sysdate", new CurrentTimestampExpression(true).ToSql(SqlDialects.Oracle, options));
+        Assert.Equal("sysdate", Sql.CurrentTimestamp(CurrentTimestampKind.SystemDate).ToSql(SqlDialects.Oracle, options));
         Assert.Contains("current_timestamp as created_at", query.ToSql(SqlDialects.PostgreSql, options));
         Assert.Equal("GETDATE()", Sql.CurrentTimestamp().ToSql(SqlDialects.TSql, new SqlGenerationOptions
         {

--- a/tests/Cyqwel.Tests/CurrentTimestampTests.cs
+++ b/tests/Cyqwel.Tests/CurrentTimestampTests.cs
@@ -1,0 +1,433 @@
+using Cyqwel.Ast;
+using Cyqwel.Dialects;
+using Cyqwel.Generation;
+using Cyqwel.Parsing;
+using Cyqwel.Validation;
+using Cyqwel.Visitors;
+
+namespace Cyqwel.Tests;
+
+public class CurrentTimestampTests
+{
+    [Theory]
+    [InlineData("generic", "CURRENT_TIMESTAMP", false)]
+    [InlineData("generic", "CURRENT_TIMESTAMP()", false)]
+    [InlineData("generic", "GETDATE()", false)]
+    [InlineData("generic", "NOW()", false)]
+    [InlineData("generic", "SYSDATE", true)]
+    [InlineData("tsql", "CURRENT_TIMESTAMP", false)]
+    [InlineData("tsql", "getdate ( )", false)]
+    [InlineData("postgresql", "current_timestamp", false)]
+    [InlineData("postgresql", "now()", false)]
+    [InlineData("mysql", "CURRENT_TIMESTAMP", false)]
+    [InlineData("mysql", "current_timestamp()", false)]
+    [InlineData("mysql", "NOW()", false)]
+    [InlineData("oracle", "CURRENT_TIMESTAMP", false)]
+    [InlineData("oracle", "sysdate", true)]
+    [InlineData("sqlite", "CURRENT_TIMESTAMP", false)]
+    public void Native_forms_parse_to_the_shared_node(string dialectName, string sql, bool systemDate)
+    {
+        var expression = ParseExpression(SqlDialectRegistry.Get(dialectName), sql);
+
+        var timestamp = Assert.IsType<CurrentTimestampExpression>(expression);
+        Assert.Equal(systemDate, timestamp.IsSystemDate);
+        if (!systemDate)
+        {
+            Assert.Equal(Sql.CurrentTimestamp(), timestamp);
+        }
+    }
+
+    [Theory]
+    [InlineData("generic", "CURRENT_TIMESTAMP")]
+    [InlineData("tsql", "GETDATE()")]
+    [InlineData("postgresql", "CURRENT_TIMESTAMP")]
+    [InlineData("mysql", "CURRENT_TIMESTAMP")]
+    [InlineData("oracle", "CURRENT_TIMESTAMP")]
+    [InlineData("sqlite", "CURRENT_TIMESTAMP")]
+    public void Builders_and_parsed_timestamps_share_target_rendering(string dialectName, string expected)
+    {
+        var dialect = SqlDialectRegistry.Get(dialectName);
+        var timestamp = Sql.CurrentTimestamp();
+        var query = Sql.SelectItems(new SelectItem(timestamp)).Build();
+
+        Assert.Equal(expected, timestamp.ToSql(dialect));
+        Assert.Equal(expected, new SqlGenerator(dialect).Generate(timestamp));
+        Assert.Equal($"SELECT {expected}", query.ToSql(dialect));
+        Assert.Equal(timestamp, ParseExpression(dialect, expected));
+        Assert.Equal(
+            $"SELECT {expected}",
+            SqlDialects.TSql.Transpile("SELECT GETDATE()", dialect));
+        Assert.Equal(
+            $"SELECT {expected}",
+            SqlDialects.PostgreSql.Transpile("SELECT NOW()", dialect));
+        Assert.Equal(
+            $"SELECT {expected}",
+            SqlDialects.MySql.Transpile("SELECT NOW()", dialect));
+    }
+
+    [Fact]
+    public void Oracle_system_date_remains_distinct_without_adding_dual()
+    {
+        const string sql = "SELECT SYSDATE, CURRENT_TIMESTAMP, TRUNC(SYSDATE)";
+        var document = SqlDialects.Oracle.Parse(sql);
+
+        Assert.Equal([true, false, true],
+            document.FindAll<CurrentTimestampExpression>().Select(timestamp => timestamp.IsSystemDate));
+        Assert.Equal(sql, document.ToSql(SqlDialects.Oracle));
+        Assert.Equal(
+            "SELECT CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, TRUNC(CURRENT_TIMESTAMP)",
+            document.ToSql(SqlDialects.PostgreSql));
+        Assert.Equal(
+            "SELECT GETDATE(), GETDATE(), TRUNC(GETDATE())",
+            document.ToSql(SqlDialects.TSql));
+        Assert.Equal(
+            "SELECT CURRENT_TIMESTAMP",
+            Sql.Select(Sql.CurrentTimestamp()).ToSql(SqlDialects.Oracle));
+        Assert.True(Assert.IsType<CurrentTimestampExpression>(
+            ParseExpression(SqlDialects.Oracle, "SYSDATE")).IsSystemDate);
+    }
+
+    [Theory]
+    [InlineData("tsql", "NOW()")]
+    [InlineData("postgresql", "GETDATE()")]
+    [InlineData("mysql", "GETDATE()")]
+    [InlineData("oracle", "NOW()")]
+    [InlineData("oracle", "SYSDATE()")]
+    [InlineData("sqlite", "NOW()")]
+    [InlineData("tsql", "CURRENT_TIMESTAMP()")]
+    [InlineData("postgresql", "CURRENT_TIMESTAMP()")]
+    [InlineData("oracle", "CURRENT_TIMESTAMP()")]
+    [InlineData("sqlite", "CURRENT_TIMESTAMP()")]
+    [InlineData("generic", "my_now()")]
+    [InlineData("generic", "NOW(3)")]
+    [InlineData("generic", "GETDATE(1)")]
+    [InlineData("generic", "CURRENT_TIMESTAMP(6)")]
+    [InlineData("postgresql", "NOW(DISTINCT)")]
+    [InlineData("postgresql", "NOW() FILTER (WHERE TRUE)")]
+    [InlineData("postgresql", "NOW() WITHIN GROUP (ORDER BY id)")]
+    [InlineData("postgresql", "NOW() OVER ()")]
+    [InlineData("generic", "CURRENT_TIMESTAMP() OVER ()")]
+    public void Other_calls_are_not_normalized(string dialectName, string sql)
+    {
+        var expression = ParseExpression(SqlDialectRegistry.Get(dialectName), sql);
+
+        Assert.Empty(expression.FindAll<CurrentTimestampExpression>());
+        Assert.Single(expression.FindAll<FunctionCallExpression>());
+    }
+
+    [Theory]
+    [InlineData("generic", "NOW")]
+    [InlineData("generic", "GETDATE")]
+    [InlineData("generic", "CURRENT_TIMESTAMP_VALUE")]
+    [InlineData("generic", "SYSDATE_VALUE")]
+    [InlineData("postgresql", "SYSDATE")]
+    [InlineData("tsql", "SYSDATE")]
+    [InlineData("mysql", "SYSDATE")]
+    [InlineData("sqlite", "SYSDATE")]
+    [InlineData("oracle", "t.sysdate")]
+    [InlineData("oracle", "t.current_timestamp")]
+    [InlineData("postgresql", "t.current_timestamp")]
+    [InlineData("oracle", "\"SYSDATE\"")]
+    [InlineData("postgresql", "\"CURRENT_TIMESTAMP\"")]
+    [InlineData("tsql", "[CURRENT_TIMESTAMP]")]
+    [InlineData("mysql", "`CURRENT_TIMESTAMP`")]
+    public void Identifier_lookalikes_remain_columns(string dialectName, string sql)
+    {
+        var dialect = SqlDialectRegistry.Get(dialectName);
+        var expression = Assert.IsType<ColumnExpression>(ParseExpression(dialect, sql));
+
+        Assert.Equal(sql, expression.ToSql(dialect));
+        Assert.IsType<ColumnExpression>(ParseExpression(dialect, expression.ToSql(dialect)));
+    }
+
+    [Theory]
+    [InlineData("postgresql", "\"now\"()")]
+    [InlineData("postgresql", "\"CURRENT_TIMESTAMP\"()")]
+    [InlineData("tsql", "[GETDATE]()")]
+    [InlineData("mysql", "`NOW`()")]
+    [InlineData("oracle", "\"NOW\"()")]
+    [InlineData("sqlite", "\"CURRENT_TIMESTAMP\"(3)")]
+    public void Quoted_calls_preserve_their_names_and_arguments(string dialectName, string sql)
+    {
+        var dialect = SqlDialectRegistry.Get(dialectName);
+        var expression = Assert.IsType<FunctionCallExpression>(ParseExpression(dialect, sql));
+
+        Assert.True(expression.Name.IsQuoted);
+        Assert.Equal(sql, expression.ToSql(dialect));
+        Assert.IsType<FunctionCallExpression>(ParseExpression(dialect, expression.ToSql(dialect)));
+    }
+
+    [Theory]
+    [InlineData("generic", "CURRENT_TIMESTAMP")]
+    [InlineData("tsql", "CURRENT_TIMESTAMP")]
+    [InlineData("oracle", "SYSDATE")]
+    [InlineData("mysql", "CURRENT_TIMESTAMP")]
+    public void Explicit_column_builders_do_not_turn_into_timestamps(string dialectName, string name)
+    {
+        var dialect = SqlDialectRegistry.Get(dialectName);
+        var sql = Sql.Col(name).ToSql(dialect);
+
+        Assert.IsType<ColumnExpression>(ParseExpression(dialect, sql));
+    }
+
+    [Theory]
+    [InlineData("generic", "UPDATE events SET current_timestamp = CURRENT_TIMESTAMP")]
+    [InlineData("oracle", "UPDATE events SET sysdate = SYSDATE")]
+    [InlineData("generic", "MERGE INTO events t USING incoming s ON t.id = s.id "
+        + "WHEN MATCHED THEN UPDATE SET current_timestamp = CURRENT_TIMESTAMP")]
+    public void Assignment_targets_are_identifiers_not_timestamp_expressions(string dialectName, string sql)
+    {
+        var dialect = SqlDialectRegistry.Get(dialectName);
+        var document = dialect.Parse(sql);
+        var assignment = Assert.Single(document.FindAll<Assignment>());
+
+        Assert.IsType<CurrentTimestampExpression>(assignment.Value);
+        var generated = document.ToSql(dialect);
+        var reparsed = Assert.Single(dialect.Parse(generated).FindAll<Assignment>());
+        Assert.Equal(assignment.Column.Parts[0].Value, reparsed.Column.Parts[0].Value);
+        Assert.IsType<CurrentTimestampExpression>(reparsed.Value);
+    }
+
+    [Theory]
+    [InlineData("generic", "CURRENT_TIMESTAMP(6)")]
+    [InlineData("postgresql", "CURRENT_TIMESTAMP(3)")]
+    [InlineData("mysql", "CURRENT_TIMESTAMP(6)")]
+    [InlineData("mysql", "NOW(3)")]
+    [InlineData("oracle", "CURRENT_TIMESTAMP(6)")]
+    public void Precision_calls_keep_their_arguments(string dialectName, string sql)
+    {
+        var dialect = SqlDialectRegistry.Get(dialectName);
+        var expression = Assert.IsType<FunctionCallExpression>(ParseExpression(dialect, sql));
+
+        Assert.Single(expression.Arguments);
+        Assert.Equal(sql, expression.ToSql(dialect));
+    }
+
+    [Theory]
+    [InlineData("tsql", "CURRENT_TIMESTAMP(3)")]
+    [InlineData("tsql", "NOW(3)")]
+    [InlineData("tsql", "GETDATE(3)")]
+    [InlineData("sqlite", "CURRENT_TIMESTAMP(3)")]
+    [InlineData("sqlite", "NOW(3)")]
+    [InlineData("oracle", "NOW(3)")]
+    [InlineData("postgresql", "NOW(3)")]
+    public void Unsupported_timestamp_arguments_are_not_silently_discarded(string dialectName, string sql)
+    {
+        var target = SqlDialectRegistry.Get(dialectName);
+        var expression = ParseExpression(SqlDialects.Generic, sql);
+
+        Assert.Throws<NotSupportedException>(() => expression.ToSql(target));
+        Assert.Equal(sql, expression.ToSql(target, new SqlGenerationOptions
+        {
+            UnsupportedBehavior = UnsupportedSqlBehavior.Ignore,
+        }));
+    }
+
+    [Theory]
+    [InlineData("generic", "CURRENT_TIMESTAMP", "CURRENT_TIMESTAMP")]
+    [InlineData("tsql", "NOW", "GETDATE()")]
+    [InlineData("tsql", "CURRENT_TIMESTAMP", "GETDATE()")]
+    [InlineData("sqlite", "NOW", "CURRENT_TIMESTAMP")]
+    [InlineData("sqlite", "CURRENT_TIMESTAMP", "CURRENT_TIMESTAMP")]
+    [InlineData("oracle", "NOW", "CURRENT_TIMESTAMP")]
+    [InlineData("oracle", "CURRENT_TIMESTAMP", "CURRENT_TIMESTAMP")]
+    public void Legacy_timestamp_function_rendering_uses_the_same_target_syntax(
+        string dialectName, string functionName, string expected)
+    {
+        Assert.Equal(expected, Sql.Func(functionName).ToSql(SqlDialectRegistry.Get(dialectName)));
+    }
+
+    [Fact]
+    public void Timestamps_work_in_nested_expressions_and_defaults()
+    {
+        var document = SqlDialects.PostgreSql.Parse(
+            "CREATE TABLE events (created_at TIMESTAMP DEFAULT NOW()); "
+            + "SELECT COALESCE(created_at, NOW()) FROM events WHERE created_at < CURRENT_TIMESTAMP");
+
+        Assert.Equal(3, document.FindAll<CurrentTimestampExpression>().Count());
+        Assert.DoesNotContain(document.GetColumnNames(),
+            name => name.Equals("CURRENT_TIMESTAMP", StringComparison.OrdinalIgnoreCase));
+        var generated = document.ToSql(SqlDialects.Oracle);
+        Assert.Contains("DEFAULT CURRENT_TIMESTAMP", generated);
+        Assert.Contains("NVL(created_at, CURRENT_TIMESTAMP)", generated);
+        Assert.Equal(generated, SqlDialects.Oracle.Parse(generated).ToSql(SqlDialects.Oracle));
+    }
+
+    [Theory]
+    [InlineData("tsql", "GETUTCDATE()")]
+    [InlineData("tsql", "SYSDATETIME()")]
+    [InlineData("tsql", "SYSDATETIMEOFFSET()")]
+    [InlineData("postgresql", "CLOCK_TIMESTAMP()")]
+    [InlineData("postgresql", "STATEMENT_TIMESTAMP()")]
+    [InlineData("postgresql", "LOCALTIMESTAMP")]
+    [InlineData("mysql", "SYSDATE()")]
+    [InlineData("oracle", "SYSTIMESTAMP")]
+    [InlineData("oracle", "CURRENT_DATE")]
+    public void Other_temporal_expressions_are_unchanged(string dialectName, string sql)
+    {
+        var dialect = SqlDialectRegistry.Get(dialectName);
+        var expression = ParseExpression(dialect, sql);
+
+        Assert.Empty(expression.FindAll<CurrentTimestampExpression>());
+        Assert.Equal(sql, expression.ToSql(dialect));
+    }
+
+    [Theory]
+    [InlineData("generic", "CURRENT_TIMESTAMP", "CURRENT_TIMESTAMP")]
+    [InlineData("tsql", "GETDATE()", "GETDATE()")]
+    [InlineData("postgresql", "NOW()", "CURRENT_TIMESTAMP")]
+    [InlineData("mysql", "NOW()", "CURRENT_TIMESTAMP")]
+    [InlineData("oracle", "SYSDATE", "SYSDATE")]
+    [InlineData("sqlite", "CURRENT_TIMESTAMP", "CURRENT_TIMESTAMP")]
+    public void Custom_dialects_inherit_parsing_and_rendering(string dialectName, string input, string expected)
+    {
+        var dialect = SqlDialectBuilder.Create($"custom-{dialectName}")
+            .BasedOn(SqlDialectRegistry.Get(dialectName))
+            .Build();
+        var timestamp = Assert.IsType<CurrentTimestampExpression>(ParseExpression(dialect, input));
+
+        Assert.Equal(expected, timestamp.ToSql(dialect));
+    }
+
+    [Fact]
+    public void Parser_cache_distinguishes_timestamp_capabilities()
+    {
+        var withoutNow = SqlDialectBuilder.Create("without-now")
+            .BasedOn(SqlDialects.PostgreSql)
+            .ConfigureParser(options => options with { CurrentTimestampSyntax = SqlCurrentTimestampSyntax.None })
+            .Build();
+        var withGetDate = SqlDialectBuilder.Create("with-getdate")
+            .BasedOn(SqlDialects.PostgreSql)
+            .ConfigureParser(options => options with { CurrentTimestampSyntax = SqlCurrentTimestampSyntax.GetDate })
+            .Build();
+
+        Assert.IsType<FunctionCallExpression>(ParseExpression(withoutNow, "NOW()"));
+        Assert.IsType<CurrentTimestampExpression>(ParseExpression(SqlDialects.PostgreSql, "NOW()"));
+        Assert.IsType<CurrentTimestampExpression>(ParseExpression(withGetDate, "GETDATE()"));
+        Assert.IsType<FunctionCallExpression>(ParseExpression(SqlDialects.PostgreSql, "GETDATE()"));
+        Assert.IsType<FunctionCallExpression>(ParseExpression(withoutNow, "NOW()"));
+    }
+
+    [Fact]
+    public void Semantic_rendering_can_be_overridden_and_generic_function_hooks_remain_available()
+    {
+        var dialect = SqlDialectBuilder.Create("custom-clock")
+            .BasedOn(new ClockDialect())
+            .WithFunctionRenderer((function, _, _) =>
+                function.Name.Value == "NOW" ? "custom_now()" : null)
+            .Build();
+
+        Assert.Equal("custom_clock()", Sql.CurrentTimestamp().ToSql(dialect));
+        Assert.Equal("custom_now()", Sql.Func("NOW").ToSql(dialect));
+        Assert.Equal("NOW()", Sql.Func("NOW").ToSql(SqlDialects.Generic));
+
+        var transformed = SqlDialectBuilder.Create("fixed-clock")
+            .WithNodeTransform(node => node is CurrentTimestampExpression ? Sql.Lit(42) : node)
+            .Build();
+        Assert.Equal("SELECT 42", Sql.Select(Sql.CurrentTimestamp()).ToSql(transformed));
+    }
+
+    [Fact]
+    public void Timestamp_rendering_respects_casing_and_pretty_print_options()
+    {
+        var options = new SqlGenerationOptions
+        {
+            UppercaseKeywords = false,
+            FunctionNameCase = FunctionNameCase.Lower,
+            PrettyPrint = true,
+        };
+        var query = Sql.SelectItems(new SelectItem(Sql.CurrentTimestamp(), "created_at")).Build();
+
+        Assert.Equal("current_timestamp", Sql.CurrentTimestamp().ToSql(SqlDialects.PostgreSql, options));
+        Assert.Equal("getdate()", Sql.CurrentTimestamp().ToSql(SqlDialects.TSql, options));
+        Assert.Equal("sysdate", new CurrentTimestampExpression(true).ToSql(SqlDialects.Oracle, options));
+        Assert.Contains("current_timestamp as created_at", query.ToSql(SqlDialects.PostgreSql, options));
+        Assert.Equal("GETDATE()", Sql.CurrentTimestamp().ToSql(SqlDialects.TSql, new SqlGenerationOptions
+        {
+            UppercaseKeywords = false,
+            FunctionNameCase = FunctionNameCase.Preserve,
+        }));
+    }
+
+    [Fact]
+    public void Timestamps_are_leaf_nodes_with_typed_visiting_and_rewriting()
+    {
+        var timestamp = Sql.CurrentTimestamp() with { Span = new SqlTextSpan(7, 17) };
+        var query = Sql.Select(timestamp).Build();
+        var visitor = new TimestampVisitor();
+        query.Accept(visitor);
+
+        Assert.Equal(1, visitor.Count);
+        Assert.Empty(timestamp.Descendants());
+        Assert.Same(timestamp, Assert.Single(timestamp.BreadthFirst()));
+        Assert.Same(query, query.Accept(new IdentityRewriter()));
+
+        var rewritten = Assert.IsType<SelectStatement>(query.Accept(new TimestampRewriter()));
+        var literal = Assert.IsType<LiteralExpression>(rewritten.Projections[0].Expression);
+        Assert.Equal(timestamp.Span, literal.Span);
+        Assert.Equal(1, literal.Value);
+        Assert.Same(timestamp, query.Projections[0].Expression);
+    }
+
+    [Fact]
+    public void Schema_validation_recognizes_timestamps_without_column_lookup()
+    {
+        var catalog = new SqlSchemaCatalog(new SqlTableSchema("events",
+        [
+            new("created_at", "timestamp"),
+            new("count", "integer"),
+        ]));
+        var options = new SqlSchemaValidationOptions { CheckTypes = true };
+        var valid = SqlValidator.Validate(
+            "UPDATE events SET created_at = NOW()",
+            catalog,
+            SqlDialects.PostgreSql,
+            options);
+        Assert.True(valid.IsValid, string.Join(Environment.NewLine, valid.Diagnostics));
+
+        var invalid = SqlValidator.Validate(
+            "UPDATE events SET count = CURRENT_TIMESTAMP",
+            catalog,
+            options: options);
+        Assert.Contains(invalid.Diagnostics, diagnostic =>
+            diagnostic.Code == SqlValidationCodes.InvalidAssignmentType);
+
+        var predicate = SqlValidator.Validate(
+            "SELECT created_at FROM events WHERE SYSDATE",
+            catalog,
+            SqlDialects.Oracle,
+            options);
+        Assert.Contains(predicate.Diagnostics, diagnostic =>
+            diagnostic.Code == SqlValidationCodes.InvalidPredicateType);
+    }
+
+    private static SqlExpression ParseExpression(SqlDialect dialect, string sql) =>
+        Assert.IsType<SelectStatement>(dialect.Parse($"SELECT {sql}").Statements[0])
+            .Projections[0].Expression;
+
+    private sealed class ClockDialect() : SqlDialect("clock")
+    {
+        public override string RenderCurrentTimestamp(
+            CurrentTimestampExpression timestamp,
+            SqlGenerationOptions options) => "custom_clock()";
+    }
+
+    private sealed class TimestampVisitor : SqlVisitor
+    {
+        public int Count { get; private set; }
+
+        protected override void VisitCurrentTimestamp(CurrentTimestampExpression node)
+        {
+            Count++;
+            base.VisitCurrentTimestamp(node);
+        }
+    }
+
+    private sealed class TimestampRewriter : SqlRewriter
+    {
+        protected override SqlNode VisitCurrentTimestamp(CurrentTimestampExpression node) =>
+            Sql.Lit(1) with { Span = node.Span };
+    }
+
+    private sealed class IdentityRewriter : SqlRewriter;
+}

--- a/tests/Cyqwel.Tests/CurrentTimestampUtcTests.cs
+++ b/tests/Cyqwel.Tests/CurrentTimestampUtcTests.cs
@@ -1,0 +1,294 @@
+using Cyqwel.Ast;
+using Cyqwel.Dialects;
+using Cyqwel.Generation;
+using Cyqwel.Parsing;
+using Cyqwel.Validation;
+using Cyqwel.Visitors;
+
+namespace Cyqwel.Tests;
+
+public class CurrentTimestampUtcTests
+{
+    [Theory]
+    [InlineData("generic", "UTC_TIMESTAMP()")]
+    [InlineData("generic", "UTC_TIMESTAMP")]
+    [InlineData("generic", "GETUTCDATE()")]
+    [InlineData("generic", "TIMEZONE('UTC', CURRENT_TIMESTAMP)")]
+    [InlineData("generic", "SYS_EXTRACT_UTC(CURRENT_TIMESTAMP)")]
+    [InlineData("generic", "SYS_EXTRACT_UTC(SYSTIMESTAMP)")]
+    [InlineData("generic", "DATETIME('now')")]
+    [InlineData("tsql", "getutcdate ( )")]
+    [InlineData("mysql", "utc_timestamp")]
+    [InlineData("mysql", "UTC_TIMESTAMP()")]
+    [InlineData("postgresql", "TIMEZONE('UTC', CURRENT_TIMESTAMP)")]
+    [InlineData("postgresql", "timezone('utc', now())")]
+    [InlineData("oracle", "SYS_EXTRACT_UTC(CURRENT_TIMESTAMP)")]
+    [InlineData("oracle", "sys_extract_utc(systimestamp)")]
+    [InlineData("sqlite", "datetime('now')")]
+    public void Native_utc_forms_parse_to_the_explicit_kind(string dialectName, string sql)
+    {
+        var timestamp = Assert.IsType<CurrentTimestampExpression>(
+            ParseExpression(SqlDialectRegistry.Get(dialectName), sql));
+
+        Assert.Equal(Sql.CurrentTimestamp(CurrentTimestampKind.Utc), timestamp);
+    }
+
+    [Theory]
+    [InlineData("generic", "UTC_TIMESTAMP()")]
+    [InlineData("tsql", "GETUTCDATE()")]
+    [InlineData("postgresql", "TIMEZONE('UTC', CURRENT_TIMESTAMP)")]
+    [InlineData("mysql", "UTC_TIMESTAMP()")]
+    [InlineData("oracle", "SYS_EXTRACT_UTC(CURRENT_TIMESTAMP)")]
+    [InlineData("sqlite", "DATETIME('now')")]
+    public void Utc_generation_and_transpilation_preserve_the_kind(string dialectName, string expected)
+    {
+        var target = SqlDialectRegistry.Get(dialectName);
+        var timestamp = Sql.CurrentTimestamp(CurrentTimestampKind.Utc);
+        var query = Sql.SelectItems(new SelectItem(timestamp)).Build();
+
+        Assert.Equal(expected, timestamp.ToSql(target));
+        Assert.Equal(expected, new SqlGenerator(target).Generate(timestamp));
+        Assert.Equal($"SELECT {expected}", query.ToSql(target));
+        Assert.Equal(timestamp, ParseExpression(target, expected));
+
+        var sources = new (SqlDialect Dialect, string Sql)[]
+        {
+            (SqlDialects.Generic, "UTC_TIMESTAMP()"),
+            (SqlDialects.TSql, "GETUTCDATE()"),
+            (SqlDialects.PostgreSql, "TIMEZONE('UTC', NOW())"),
+            (SqlDialects.MySql, "UTC_TIMESTAMP"),
+            (SqlDialects.Oracle, "SYS_EXTRACT_UTC(SYSTIMESTAMP)"),
+            (SqlDialects.Sqlite, "DATETIME('now')"),
+        };
+        foreach (var (source, sql) in sources)
+        {
+            var generated = source.Transpile($"SELECT {sql}", target);
+            Assert.Equal($"SELECT {expected}", generated);
+            Assert.Equal(generated, target.Parse(generated).ToSql(target));
+        }
+
+        var inherited = SqlDialectBuilder.Create($"utc-{dialectName}").BasedOn(target).Build();
+        Assert.Equal(expected, timestamp.ToSql(inherited));
+        Assert.Equal(timestamp, ParseExpression(inherited, expected));
+    }
+
+    [Theory]
+    [InlineData("tsql", "UTC_TIMESTAMP()")]
+    [InlineData("postgresql", "GETUTCDATE()")]
+    [InlineData("postgresql", "UTC_TIMESTAMP()")]
+    [InlineData("mysql", "TIMEZONE('UTC', CURRENT_TIMESTAMP)")]
+    [InlineData("sqlite", "TIMEZONE('UTC', CURRENT_TIMESTAMP)")]
+    [InlineData("postgresql", "SYS_EXTRACT_UTC(CURRENT_TIMESTAMP)")]
+    [InlineData("oracle", "DATETIME('now')")]
+    [InlineData("mysql", "UTC_TIMESTAMP(3)")]
+    [InlineData("tsql", "GETUTCDATE(3)")]
+    [InlineData("mysql", "UTC_TIMESTAMP(DISTINCT)")]
+    [InlineData("postgresql", "TIMEZONE('UTC', NOW()) FILTER (WHERE TRUE)")]
+    [InlineData("tsql", "GETUTCDATE() OVER ()")]
+    [InlineData("mysql", "`UTC_TIMESTAMP`()")]
+    [InlineData("tsql", "[GETUTCDATE]()")]
+    [InlineData("postgresql", "\"timezone\"('UTC', CURRENT_TIMESTAMP)")]
+    [InlineData("oracle", "SYS_EXTRACT_UTC(\"SYSTIMESTAMP\")")]
+    [InlineData("oracle", "SYS_EXTRACT_UTC(t.SYSTIMESTAMP)")]
+    [InlineData("oracle", "SYS_EXTRACT_UTC(SYSDATE)")]
+    [InlineData("oracle", "SYS_EXTRACT_UTC(created_at)")]
+    [InlineData("postgresql", "TIMEZONE('America/New_York', CURRENT_TIMESTAMP)")]
+    [InlineData("postgresql", "TIMEZONE(zone, CURRENT_TIMESTAMP)")]
+    [InlineData("postgresql", "TIMEZONE('UTC', created_at)")]
+    [InlineData("postgresql", "TIMEZONE('UTC', CURRENT_TIMESTAMP, 3)")]
+    [InlineData("postgresql", "TIMEZONE('UTC', CURRENT_TIMESTAMP(3))")]
+    [InlineData("oracle", "SYS_EXTRACT_UTC(CURRENT_TIMESTAMP(3))")]
+    [InlineData("sqlite", "DATETIME('now', 'localtime')")]
+    [InlineData("sqlite", "DATETIME('now', 'utc')")]
+    [InlineData("sqlite", "DATETIME('now', 'subsec')")]
+    [InlineData("sqlite", "DATETIME('2020-01-01')")]
+    public void Only_known_unmodified_utc_shapes_are_normalized(string dialectName, string sql)
+    {
+        var expression = ParseExpression(SqlDialectRegistry.Get(dialectName), sql);
+
+        Assert.False(expression is CurrentTimestampExpression);
+        Assert.DoesNotContain(expression.FindAll<CurrentTimestampExpression>(),
+            timestamp => timestamp.Kind == CurrentTimestampKind.Utc);
+    }
+
+    [Theory]
+    [InlineData("postgresql", "TIMEZONE('UTC', TIMEZONE('UTC', CURRENT_TIMESTAMP))")]
+    [InlineData("oracle", "SYS_EXTRACT_UTC(SYS_EXTRACT_UTC(CURRENT_TIMESTAMP))")]
+    public void Converting_an_already_utc_timestamp_is_not_collapsed(string dialectName, string sql)
+    {
+        var dialect = SqlDialectRegistry.Get(dialectName);
+        var expression = Assert.IsType<FunctionCallExpression>(ParseExpression(dialect, sql));
+
+        Assert.Equal(CurrentTimestampKind.Utc, Assert.Single(expression.FindAll<CurrentTimestampExpression>()).Kind);
+        Assert.Equal(sql, expression.ToSql(dialect));
+    }
+
+    [Theory]
+    [InlineData("generic", "UTC_TIMESTAMP(3)")]
+    [InlineData("mysql", "UTC_TIMESTAMP(3)")]
+    [InlineData("postgresql", "TIMEZONE('UTC', CURRENT_TIMESTAMP(3))")]
+    [InlineData("oracle", "SYS_EXTRACT_UTC(CURRENT_TIMESTAMP(3))")]
+    [InlineData("sqlite", "DATETIME('now', 'subsec')")]
+    public void Explicit_precision_is_preserved_outside_the_utc_node(string dialectName, string sql)
+    {
+        var dialect = SqlDialectRegistry.Get(dialectName);
+        var expression = Assert.IsType<FunctionCallExpression>(ParseExpression(dialect, sql));
+
+        Assert.Equal(sql, expression.ToSql(dialect));
+    }
+
+    [Theory]
+    [InlineData("tsql", "UTC_TIMESTAMP(3)")]
+    [InlineData("tsql", "GETUTCDATE(3)")]
+    [InlineData("postgresql", "UTC_TIMESTAMP(3)")]
+    [InlineData("oracle", "UTC_TIMESTAMP(3)")]
+    [InlineData("sqlite", "UTC_TIMESTAMP(3)")]
+    public void Unsupported_utc_precision_is_not_silently_dropped(string dialectName, string sql)
+    {
+        var target = SqlDialectRegistry.Get(dialectName);
+        var expression = ParseExpression(SqlDialects.Generic, sql);
+
+        Assert.Throws<NotSupportedException>(() => expression.ToSql(target));
+        Assert.Equal(sql, expression.ToSql(target, new SqlGenerationOptions
+        {
+            UnsupportedBehavior = UnsupportedSqlBehavior.Ignore,
+        }));
+    }
+
+    [Theory]
+    [InlineData("mysql", "`UTC_TIMESTAMP`")]
+    [InlineData("mysql", "t.UTC_TIMESTAMP")]
+    [InlineData("mysql", "`UTC_TIMESTAMP`()")]
+    [InlineData("tsql", "[GETUTCDATE]()")]
+    [InlineData("tsql", "GETUTCDATE")]
+    [InlineData("postgresql", "UTC_TIMESTAMP")]
+    public void Utc_identifier_lookalikes_round_trip(string dialectName, string sql)
+    {
+        var dialect = SqlDialectRegistry.Get(dialectName);
+        var expression = ParseExpression(dialect, sql);
+
+        Assert.False(expression is CurrentTimestampExpression);
+        Assert.Equal(sql, expression.ToSql(dialect));
+    }
+
+    [Fact]
+    public void Explicit_utc_timestamp_columns_are_quoted_only_where_needed()
+    {
+        Assert.Equal("\"UTC_TIMESTAMP\"", Sql.Col("UTC_TIMESTAMP").ToSql());
+        Assert.Equal("`UTC_TIMESTAMP`", Sql.Col("UTC_TIMESTAMP").ToSql(SqlDialects.MySql));
+        Assert.Equal("UTC_TIMESTAMP", Sql.Col("UTC_TIMESTAMP").ToSql(SqlDialects.PostgreSql));
+        var update = Sql.Update("events").Set("UTC_TIMESTAMP", Sql.CurrentTimestamp(CurrentTimestampKind.Utc)).Build();
+        var generated = update.ToSql(SqlDialects.MySql);
+        var assignment = Assert.Single(SqlDialects.MySql.Parse(generated).FindAll<Assignment>());
+
+        Assert.True(assignment.Column.Parts[0].IsQuoted);
+        Assert.Equal(CurrentTimestampKind.Utc, Assert.IsType<CurrentTimestampExpression>(assignment.Value).Kind);
+    }
+
+    [Fact]
+    public void Utc_parser_capabilities_are_part_of_the_cache_key()
+    {
+        var withoutUtc = SqlDialectBuilder.Create("without-utc")
+            .BasedOn(SqlDialects.MySql)
+            .ConfigureParser(options => options with
+            {
+                CurrentTimestampSyntax = options.CurrentTimestampSyntax & ~SqlCurrentTimestampSyntax.UtcTimestamp,
+            })
+            .Build();
+        var withoutWrapper = SqlDialectBuilder.Create("without-utc-wrapper")
+            .BasedOn(SqlDialects.PostgreSql)
+            .ConfigureParser(options => options with { CurrentTimestampSyntax = SqlCurrentTimestampSyntax.Now })
+            .Build();
+
+        Assert.IsType<FunctionCallExpression>(ParseExpression(withoutUtc, "UTC_TIMESTAMP()"));
+        Assert.IsType<ColumnExpression>(ParseExpression(withoutUtc, "UTC_TIMESTAMP"));
+        Assert.IsType<CurrentTimestampExpression>(ParseExpression(SqlDialects.MySql, "UTC_TIMESTAMP()"));
+        Assert.IsType<FunctionCallExpression>(ParseExpression(withoutWrapper, "TIMEZONE('UTC', NOW())"));
+        Assert.IsType<CurrentTimestampExpression>(ParseExpression(SqlDialects.PostgreSql, "TIMEZONE('UTC', NOW())"));
+    }
+
+    [Theory]
+    [InlineData("generic", "utc_timestamp()")]
+    [InlineData("tsql", "getutcdate()")]
+    [InlineData("postgresql", "timezone('UTC', current_timestamp)")]
+    [InlineData("mysql", "utc_timestamp()")]
+    [InlineData("oracle", "sys_extract_utc(current_timestamp)")]
+    [InlineData("sqlite", "datetime('now')")]
+    public void Utc_rendering_respects_casing(string dialectName, string expected)
+    {
+        var options = new SqlGenerationOptions
+        {
+            UppercaseKeywords = false,
+            FunctionNameCase = FunctionNameCase.Lower,
+        };
+        Assert.Equal(expected, Sql.CurrentTimestamp(CurrentTimestampKind.Utc)
+            .ToSql(SqlDialectRegistry.Get(dialectName), options));
+    }
+
+    [Fact]
+    public void Utc_kind_is_preserved_by_visitors_and_transforms()
+    {
+        var timestamp = Sql.CurrentTimestamp(CurrentTimestampKind.Utc);
+        var document = Sql.SelectItems(new SelectItem(timestamp)).Build();
+        var visitor = new TimestampVisitor();
+        document.Accept(visitor);
+
+        Assert.Equal(CurrentTimestampKind.Utc, Assert.Single(visitor.Kinds));
+        Assert.Same(document, document.Accept(new IdentityRewriter()));
+        Assert.Empty(timestamp.Descendants());
+        var dialect = SqlDialectBuilder.Create("utc-override")
+            .WithNodeTransform(node => node is CurrentTimestampExpression { Kind: CurrentTimestampKind.Utc }
+                ? Sql.Lit(1) : node)
+            .Build();
+        Assert.Equal("SELECT 1", document.ToSql(dialect));
+        Assert.Equal("SELECT CURRENT_TIMESTAMP", Sql.Select(Sql.CurrentTimestamp()).ToSql(dialect));
+    }
+
+    [Theory]
+    [InlineData("tsql", "GETUTCDATE()")]
+    [InlineData("postgresql", "TIMEZONE('UTC', CURRENT_TIMESTAMP)")]
+    [InlineData("mysql", "UTC_TIMESTAMP()")]
+    [InlineData("oracle", "SYS_EXTRACT_UTC(CURRENT_TIMESTAMP)")]
+    [InlineData("sqlite", "DATETIME('now')")]
+    public void Utc_expressions_have_timestamp_types_and_work_in_defaults(string dialectName, string sql)
+    {
+        var dialect = SqlDialectRegistry.Get(dialectName);
+        var catalog = new SqlSchemaCatalog(new SqlTableSchema("events",
+        [
+            new("created_at", "timestamp"),
+            new("count", "integer"),
+        ]));
+        var options = new SqlSchemaValidationOptions { CheckTypes = true };
+
+        Assert.True(SqlValidator.Validate($"UPDATE events SET created_at = {sql}", catalog, dialect, options).IsValid);
+        Assert.Contains(SqlValidator.Validate($"UPDATE events SET count = {sql}", catalog, dialect, options).Diagnostics,
+            diagnostic => diagnostic.Code == SqlValidationCodes.InvalidAssignmentType);
+        var document = dialect.Parse($"CREATE TABLE events (created_at TIMESTAMP DEFAULT ({sql}))");
+        Assert.Equal(CurrentTimestampKind.Utc, Assert.Single(document.FindAll<CurrentTimestampExpression>()).Kind);
+        var generated = document.ToSql(dialect);
+        Assert.Equal(generated, dialect.Parse(generated).ToSql(dialect));
+    }
+
+    [Fact]
+    public void Undefined_kinds_are_rejected()
+    {
+        var invalid = (CurrentTimestampKind)(-1);
+        Assert.Throws<ArgumentOutOfRangeException>(() => Sql.CurrentTimestamp(invalid));
+        foreach (var dialect in SqlDialects.BuiltIn)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new CurrentTimestampExpression(invalid).ToSql(dialect));
+        }
+    }
+
+    private static SqlExpression ParseExpression(SqlDialect dialect, string sql) =>
+        Assert.IsType<SelectStatement>(dialect.Parse($"SELECT {sql}").Statements[0]).Projections[0].Expression;
+
+    private sealed class IdentityRewriter : SqlRewriter;
+
+    private sealed class TimestampVisitor : SqlVisitor
+    {
+        public List<CurrentTimestampKind> Kinds { get; } = [];
+
+        protected override void VisitCurrentTimestamp(CurrentTimestampExpression node) => Kinds.Add(node.Kind);
+    }
+}

--- a/tests/Cyqwel.Tests/ParserTests.cs
+++ b/tests/Cyqwel.Tests/ParserTests.cs
@@ -66,13 +66,13 @@ public class ParserTests
     }
 
     [Fact]
-    public void Parses_empty_functions_and_tsql_offset_fetch()
+    public void Parses_current_timestamp_and_tsql_offset_fetch()
     {
         var document = SqlDialects.TSql.Parse(
             "SELECT GETDATE() FROM users ORDER BY id OFFSET 20 ROWS FETCH NEXT 10 ROWS ONLY");
         var select = Assert.IsType<SelectStatement>(Assert.Single(document.Statements));
 
-        Assert.IsType<FunctionCallExpression>(Assert.Single(select.Projections).Expression);
+        Assert.IsType<CurrentTimestampExpression>(Assert.Single(select.Projections).Expression);
         Assert.Equal(20L, Assert.IsType<LiteralExpression>(select.Offset).Value);
         Assert.Equal(10L, Assert.IsType<LiteralExpression>(select.Limit).Value);
     }


### PR DESCRIPTION
Current timestamp syntax currently parses as either generic function calls or column references, leaving target-specific name substitutions to produce inconsistent SQL. This change gives parsed SQL and fluent builders a shared semantic representation and generation path.

Adds `CurrentTimestampExpression` and `Sql.CurrentTimestamp(kind)`, with `CurrentTimestampKind.Default`, `SystemDate`, and `Utc`. Default behavior renders `GETDATE()` for T-SQL and bare `CURRENT_TIMESTAMP` for the other built-in dialects. Oracle `SYSDATE` retains the SystemDate kind so Oracle round-trips preserve its semantics.

Explicit UTC mode returns UTC date/time fields without a timezone offset and does not change session settings. It renders `GETUTCDATE()` for T-SQL, `UTC_TIMESTAMP()` for Generic/MySQL, `TIMEZONE('UTC', CURRENT_TIMESTAMP)` for PostgreSQL, `SYS_EXTRACT_UTC(CURRENT_TIMESTAMP)` for Oracle, and `DATETIME('now')` for SQLite. Native UTC forms normalize during parsing, and generated forms round-trip with the UTC kind intact. Native SQL types, precision, and clock evaluation timing still vary across databases.

The shared node integrates with custom-dialect inheritance, visitors/rewriters, schema type handling, and fluent builders. Quoted names, assignment targets, arbitrary timezone conversions, and explicit precision are preserved; unsupported timestamp argument forms are rejected rather than silently losing precision. Higher-precision variants such as `SYSUTCDATETIME()`, local-time, date-only, and separate wall-clock functions remain outside this normalization. Oracle remains 23+ without automatic `FROM DUAL` insertion.

Includes documentation and regression coverage for all built-in targets, UTC semantics, builder parity, custom dialects, Oracle round-trips, quoted lookalikes, assignment targets, and precision safeguards.

Fixes: #16